### PR TITLE
[Feature] CSRF 토큰 쿠키,헤더 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // Swagger UI 활성화
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'

--- a/src/main/java/com/onepiece/otboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/onepiece/otboo/domain/auth/controller/AuthController.java
@@ -1,0 +1,20 @@
+package com.onepiece.otboo.domain.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    @GetMapping("/csrf-token")
+    public ResponseEntity<Void> getCsrfToken(CsrfToken csrfToken) {
+        csrfToken.getToken();
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/onepiece/otboo/domain/auth/controller/api/AuthApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/auth/controller/api/AuthApi.java
@@ -1,0 +1,28 @@
+package com.onepiece.otboo.domain.auth.controller.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "인증 및 보안 관련 API")
+@RestController
+@RequestMapping("/api/auth")
+public class AuthApi {
+
+    @Operation(summary = "CSRF 토큰 조회", description = "CSRF 토큰을 조회합니다. 토큰은 쿠키(XSRF-TOKEN)에 저장됩니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "CSRF 토큰 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "CSRF 토큰 조회 실패")
+    })
+    @GetMapping("/csrf-token")
+    public ResponseEntity<Void> getCsrfToken(CsrfToken csrfToken) {
+        csrfToken.getToken();
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/onepiece/otboo/infra/security/config/SecurityConfig.java
+++ b/src/main/java/com/onepiece/otboo/infra/security/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.onepiece.otboo.infra.security.config;
+
+import com.onepiece.otboo.infra.security.handler.SpaCsrfTokenRequestHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@Profile("!test")
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http)
+        throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/csrf-token").permitAll()
+                .anyRequest().permitAll()
+            )
+            .csrf(csrf -> csrf
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler())
+            )
+            .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()));
+        return http.build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/onepiece/otboo/infra/security/handler/SpaCsrfTokenRequestHandler.java
+++ b/src/main/java/com/onepiece/otboo/infra/security/handler/SpaCsrfTokenRequestHandler.java
@@ -1,0 +1,45 @@
+package com.onepiece.otboo.infra.security.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.function.Supplier;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
+import org.springframework.util.StringUtils;
+
+public class SpaCsrfTokenRequestHandler implements CsrfTokenRequestHandler {
+
+    private final CsrfTokenRequestHandler plain;
+    private final CsrfTokenRequestHandler xor;
+
+    public SpaCsrfTokenRequestHandler() {
+        this(new CsrfTokenRequestAttributeHandler(), new XorCsrfTokenRequestAttributeHandler());
+    }
+
+    public SpaCsrfTokenRequestHandler(CsrfTokenRequestHandler plain, CsrfTokenRequestHandler xor) {
+        this.plain = plain;
+        this.xor = xor;
+    }
+
+    @Override
+    public void handle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Supplier<CsrfToken> csrfToken
+    ) {
+        this.xor.handle(request, response, csrfToken);
+        csrfToken.get();
+    }
+
+    @Override
+    public String resolveCsrfTokenValue(
+        HttpServletRequest request,
+        CsrfToken csrfToken
+    ) {
+        String headerValue = request.getHeader(csrfToken.getHeaderName());
+        return (StringUtils.hasText(headerValue) ? this.plain : this.xor)
+            .resolveCsrfTokenValue(request, csrfToken);
+    }
+}

--- a/src/main/java/com/onepiece/otboo/infra/security/handler/SpaCsrfTokenRequestHandler.java
+++ b/src/main/java/com/onepiece/otboo/infra/security/handler/SpaCsrfTokenRequestHandler.java
@@ -9,18 +9,13 @@ import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
 import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
 import org.springframework.util.StringUtils;
 
-public class SpaCsrfTokenRequestHandler implements CsrfTokenRequestHandler {
-
-    private final CsrfTokenRequestHandler plain;
-    private final CsrfTokenRequestHandler xor;
+public record SpaCsrfTokenRequestHandler(
+    CsrfTokenRequestHandler plain,
+    CsrfTokenRequestHandler xor
+) implements CsrfTokenRequestHandler {
 
     public SpaCsrfTokenRequestHandler() {
         this(new CsrfTokenRequestAttributeHandler(), new XorCsrfTokenRequestAttributeHandler());
-    }
-
-    public SpaCsrfTokenRequestHandler(CsrfTokenRequestHandler plain, CsrfTokenRequestHandler xor) {
-        this.plain = plain;
-        this.xor = xor;
     }
 
     @Override

--- a/src/test/java/com/onepiece/otboo/OtbooApplicationTests.java
+++ b/src/test/java/com/onepiece/otboo/OtbooApplicationTests.java
@@ -1,9 +1,9 @@
 package com.onepiece.otboo;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@ActiveProfiles("test")
 class OtbooApplicationTests {
 
     @Test

--- a/src/test/java/com/onepiece/otboo/domain/auth/controller/CsrfTokenControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/auth/controller/CsrfTokenControllerTest.java
@@ -1,0 +1,33 @@
+package com.onepiece.otboo.domain.auth.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.onepiece.otboo.infra.security.config.SecurityConfig;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@ActiveProfiles("test-security")
+@Import(SecurityConfig.class)
+@WebMvcTest(AuthController.class)
+class CsrfTokenControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void CSRF_토큰_발급_엔드포인트는_204와_쿠키를_반환한다() throws Exception {
+        ResultActions result = mockMvc.perform(get("/api/auth/csrf-token"));
+        result.andExpect(status().isNoContent());
+        Cookie cookie = result.andReturn().getResponse().getCookie("XSRF-TOKEN");
+        assertThat(cookie).isNotNull();
+        assertThat(cookie.getValue()).isNotEmpty();
+    }
+}

--- a/src/test/java/com/onepiece/otboo/infra/security/handler/SpaCsrfTokenRequestHandlerTest.java
+++ b/src/test/java/com/onepiece/otboo/infra/security/handler/SpaCsrfTokenRequestHandlerTest.java
@@ -1,0 +1,62 @@
+package com.onepiece.otboo.infra.security.handler;
+
+import com.onepiece.otboo.infra.security.config.SecurityConfig;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test-security")
+@Import(SecurityConfig.class)
+class SpaCsrfTokenRequestHandlerTest {
+
+    @Test
+    void 헤더가_있으면_plain_없으면_xor_방식으로_분기한다() {
+        // given
+        CsrfTokenRequestHandler mockPlain = Mockito.mock(CsrfTokenRequestHandler.class);
+        CsrfTokenRequestHandler mockXor = Mockito.mock(CsrfTokenRequestHandler.class);
+        SpaCsrfTokenRequestHandler handler = new SpaCsrfTokenRequestHandler(mockPlain, mockXor);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        CsrfToken token = Mockito.mock(CsrfToken.class);
+        Mockito.when(token.getHeaderName()).thenReturn("X-XSRF-TOKEN");
+
+        // when: 헤더가 있으면 plain 핸들러 호출
+        Mockito.when(request.getHeader("X-XSRF-TOKEN")).thenReturn("token-value");
+        handler.resolveCsrfTokenValue(request, token);
+
+        // then
+        Mockito.verify(mockPlain).resolveCsrfTokenValue(request, token);
+        Mockito.verify(mockXor, Mockito.never()).resolveCsrfTokenValue(request, token);
+
+        // when: 헤더가 없으면 xor 핸들러 호출
+        Mockito.when(request.getHeader("X-XSRF-TOKEN")).thenReturn(null);
+        handler.resolveCsrfTokenValue(request, token);
+
+        // then
+        Mockito.verify(mockXor).resolveCsrfTokenValue(request, token);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handle은_xor_핸들러를_항상_호출한다() {
+        // given
+        CsrfTokenRequestHandler mockPlain = Mockito.mock(CsrfTokenRequestHandler.class);
+        CsrfTokenRequestHandler mockXor = Mockito.mock(CsrfTokenRequestHandler.class);
+        SpaCsrfTokenRequestHandler handler = new SpaCsrfTokenRequestHandler(mockPlain, mockXor);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        Supplier<CsrfToken> supplier = Mockito.mock(Supplier.class);
+
+        // when
+        handler.handle(request, response, supplier);
+
+        // then
+        Mockito.verify(mockXor).handle(request, response, supplier);
+        Mockito.verify(supplier).get();
+    }
+}

--- a/src/test/resources/application-test-security.yaml
+++ b/src/test/resources/application-test-security.yaml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    import: optional:file:.env[.properties]
+
+logging:
+  level:
+    com.onepiece.otboo: debug
+    org.hibernate.SQL: debug
+    org.springframework.security: trace


### PR DESCRIPTION
## 📌 작업 개요

- csrf 토큰은 쿠키에 저장하는 방식으로 관리하세요.
    - 쿠키 이름: XSRF-TOKEN
    - 헤더 이름: X-XSRF-TOKEN

## ✅ 완료한 작업

- csrf 토큰은 쿠키에 저장하는 방식으로 관리합니다.
    - 쿠키 이름: XSRF-TOKEN
    - 헤더 이름: X-XSRF-TOKEN
- SpaCsrfTokenRequestHandler 생성

## 🧪 테스트 결과

- [x] csrf 토큰 정상 발급 및 조회
- [x] SpaCsrfTokenRequestHandler 정상 동작

---

## Related Issue

Closes #26 
