### PR TITLE
[Feature] 사용자 등록(회원가입) 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,10 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'com.h2database:h2'
 
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/onepiece/otboo/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/repository/ProfileRepository.java
@@ -1,0 +1,11 @@
+package com.onepiece.otboo.domain.profile.repository;
+
+import com.onepiece.otboo.domain.profile.entity.Profile;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProfileRepository extends JpaRepository<Profile, UUID> {
+
+}

--- a/src/main/java/com/onepiece/otboo/domain/user/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/api/UserApi.java
@@ -1,5 +1,42 @@
 package com.onepiece.otboo.domain.user.api;
 
-public class UserApi {
+import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
+import com.onepiece.otboo.domain.user.dto.response.UserDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.RequestBody;
 
+@Tag(name = "프로필 관리", description = "프로필 관련 API")
+public interface UserApi {
+
+    @Operation(
+        summary = "사용자 등록(회원가입)"
+        , description = "사용자 등록(회원가입) API"
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "201", description = "사용자 등록(회원가입) 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = UserDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400", description = "사용자 등록(회원가입) 실패",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<UserDto> create(UserCreateRequest userCreateRequest);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.onepiece.otboo.domain.user.controller;
 
-import com.onepiece.otboo.domain.user.api.UserApi;
+import com.onepiece.otboo.domain.user.controller.api.UserApi;
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
 import com.onepiece.otboo.domain.user.service.UserService;

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -1,5 +1,39 @@
 package com.onepiece.otboo.domain.user.controller;
 
-public class UserController {
+import com.onepiece.otboo.domain.user.api.UserApi;
+import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
+import com.onepiece.otboo.domain.user.dto.response.UserDto;
+import com.onepiece.otboo.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController implements UserApi {
+
+    private final UserService userService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<UserDto> create(@Valid @RequestBody UserCreateRequest userCreateRequest) {
+
+        log.info("[UserController] 회원가입 요청 - email: {}, name: {}",
+            userCreateRequest.email(), userCreateRequest.name());
+
+        UserDto result = userService.create(userCreateRequest);
+
+        log.info("[UserController] 회원가입 성공 - id: {}, email: {}",
+            result.id(), result.email());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -1,4 +1,4 @@
-package com.onepiece.otboo.domain.user.api;
+package com.onepiece.otboo.domain.user.controller.api;
 
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -38,5 +38,5 @@ public interface UserApi {
             )
         )
     })
-    ResponseEntity<UserDto> create(UserCreateRequest userCreateRequest);
+    ResponseEntity<UserDto> create(@Valid @RequestBody UserCreateRequest userCreateRequest);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserCreateRequest.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserCreateRequest.java
@@ -16,7 +16,7 @@ public record UserCreateRequest(
 
     @NotBlank
     @Pattern(
-        regexp = "(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{6,100}$",
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{6,100}$",
         message = "비밀번호는 영어, 숫자, 특수문자를 포함하여 6자 이상 입력해야 합니다."
     )
     String password

--- a/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserCreateRequest.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserCreateRequest.java
@@ -7,7 +7,11 @@ import jakarta.validation.constraints.Size;
 
 public record UserCreateRequest(
     @NotBlank
-    @Size(max = 100, message = "이름은 100자까지만 입력 가능합니다.")
+    @Size(min = 2, max = 20, message = "이름은 2~20자여야 합니다.")
+    @Pattern(
+        regexp = "^[가-힣a-zA-Z0-9]+$",
+        message = "이름은 한글, 영문, 숫자만 입력 가능합니다."
+    )
     String name,
 
     @NotBlank
@@ -15,9 +19,10 @@ public record UserCreateRequest(
     String email,
 
     @NotBlank
+    @Size(min = 6, max = 100, message = "비밀번호는 6~100자여야 합니다.")
     @Pattern(
-        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{6,100}$",
-        message = "비밀번호는 영어, 숫자, 특수문자를 포함하여 6자 이상 입력해야 합니다."
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z0-9@$!%*#?&]+$",
+        message = "비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다."
     )
     String password
 ) {

--- a/src/main/java/com/onepiece/otboo/domain/user/dto/response/UserDto.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/dto/response/UserDto.java
@@ -5,7 +5,9 @@ import com.onepiece.otboo.domain.user.enums.Role;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import lombok.Builder;
 
+@Builder
 public record UserDto(
     UUID id,
     Instant createdAt,

--- a/src/main/java/com/onepiece/otboo/domain/user/dto/response/UserDto.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/dto/response/UserDto.java
@@ -12,6 +12,7 @@ public record UserDto(
     UUID id,
     Instant createdAt,
     String email,
+    String name,
     Role role,
     List<Provider> linkedOAuthProviders,
     boolean locked

--- a/src/main/java/com/onepiece/otboo/domain/user/exception/DuplicateEmailException.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/exception/DuplicateEmailException.java
@@ -1,0 +1,11 @@
+package com.onepiece.otboo.domain.user.exception;
+
+import com.onepiece.otboo.global.exception.ErrorCode;
+import java.util.Map;
+
+public class DuplicateEmailException extends UserException {
+
+    public DuplicateEmailException(ErrorCode errorCode, Map<String, Object> details) {
+        super(errorCode, details);
+    }
+}

--- a/src/main/java/com/onepiece/otboo/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/mapper/UserMapper.java
@@ -1,5 +1,28 @@
 package com.onepiece.otboo.domain.user.mapper;
 
-public class UserMapper {
+import com.onepiece.otboo.domain.profile.entity.Profile;
+import com.onepiece.otboo.domain.user.dto.response.UserDto;
+import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.domain.user.enums.Provider;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+
+    // User + Profile → UserDto
+    @Mapping(target = "id", source = "user.id")
+    @Mapping(target = "createdAt", source = "user.createdAt")
+    @Mapping(target = "email", source = "user.email")
+    @Mapping(target = "name", source = "profile.nickname")  // Profile.nickname 매핑
+    @Mapping(target = "role", source = "user.role")
+    @Mapping(target = "linkedOAuthProviders", expression = "java(toProviders(user))")
+    @Mapping(target = "locked", source = "user.locked")
+    UserDto toDto(User user, Profile profile);
+
+    // 필요 시 Provider 리스트 변환 로직
+    default List<Provider> toProviders(User user) {
+        return List.of(user.getProvider()); // 단일 Provider만 갖는 경우
+    }
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/repository/UserRepository.java
@@ -1,5 +1,12 @@
 package com.onepiece.otboo.domain.user.repository;
 
-public class UserRepository {
+import com.onepiece.otboo.domain.user.entity.User;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserService.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserService.java
@@ -1,5 +1,9 @@
 package com.onepiece.otboo.domain.user.service;
 
-public class UserService {
+import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
+import com.onepiece.otboo.domain.user.dto.response.UserDto;
 
+public interface UserService {
+
+    UserDto create(UserCreateRequest userCreateRequest);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
@@ -11,12 +11,12 @@ import com.onepiece.otboo.domain.user.exception.DuplicateEmailException;
 import com.onepiece.otboo.domain.user.mapper.UserMapper;
 import com.onepiece.otboo.domain.user.repository.UserRepository;
 import com.onepiece.otboo.global.exception.ErrorCode;
-import jakarta.transaction.Transactional;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
@@ -1,9 +1,21 @@
 package com.onepiece.otboo.domain.user.service;
 
+import com.onepiece.otboo.domain.profile.entity.Profile;
+import com.onepiece.otboo.domain.profile.repository.ProfileRepository;
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
+import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.domain.user.enums.Provider;
+import com.onepiece.otboo.domain.user.enums.Role;
+import com.onepiece.otboo.domain.user.exception.DuplicateEmailException;
+import com.onepiece.otboo.domain.user.mapper.UserMapper;
+import com.onepiece.otboo.domain.user.repository.UserRepository;
+import com.onepiece.otboo.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -11,8 +23,48 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
+    private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
+    private final UserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
+
     @Override
+    @Transactional
     public UserDto create(UserCreateRequest userCreateRequest) {
-        return null;
+
+        String email = userCreateRequest.email();
+        if (userRepository.existsByEmail(email)) {
+            throw new DuplicateEmailException(ErrorCode.DUPLICATE_EMAIL, Map.of("email", email));
+        }
+
+        log.info("[UserService] 사용자 등록 요청 - name: {}, email: {}", userCreateRequest.name(),
+            userCreateRequest.email());
+
+        String encodedPassword = passwordEncoder.encode(userCreateRequest.password());
+
+        User user = User.builder()
+            .provider(Provider.LOCAL)
+            .email(email)
+            .password(encodedPassword)
+            .role(Role.USER)
+            .locked(false)
+            .build();
+
+        User savedUser = userRepository.save(user);
+        Profile profile = createProfile(savedUser, userCreateRequest.name());
+
+        log.info("[UserService] 사용자 및 프로필 등록 완료 - userId: {}, profileId: {}",
+            savedUser.getId(), profile.getId());
+
+        return userMapper.toDto(savedUser, profile);
+    }
+
+    private Profile createProfile(User user, String name) {
+        Profile profile = Profile.builder()
+            .user(user)
+            .nickname(name)
+            .build();
+
+        return profileRepository.save(profile);
     }
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,18 @@
+package com.onepiece.otboo.domain.user.service;
+
+import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
+import com.onepiece.otboo.domain.user.dto.response.UserDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    @Override
+    public UserDto create(UserCreateRequest userCreateRequest) {
+        return null;
+    }
+}

--- a/src/main/java/com/onepiece/otboo/global/config/Config.java
+++ b/src/main/java/com/onepiece/otboo/global/config/Config.java
@@ -1,5 +1,0 @@
-package com.onepiece.otboo.global.config;
-
-public class Config {
-
-}

--- a/src/main/java/com/onepiece/otboo/global/config/JpaConfig.java
+++ b/src/main/java/com/onepiece/otboo/global/config/JpaConfig.java
@@ -1,0 +1,12 @@
+package com.onepiece.otboo.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+@Profile("!test")
+public class JpaConfig {
+
+}

--- a/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
 
     // USER
     USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "사용자 등록 실패", "사용자가 이미 존재합니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 확인 실패", "존재하지 않는 사용자입니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 확인 실패", "존재하지 않는 사용자입니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일", "이미 존재하는 이메일입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/onepiece/otboo/infra/security/config/SecurityConfig.java
+++ b/src/main/java/com/onepiece/otboo/infra/security/config/SecurityConfig.java
@@ -2,8 +2,11 @@ package com.onepiece.otboo.infra.security.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
@@ -11,5 +14,29 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            // H2 콘솔 & 회원 API는 CSRF 검사 제외 (개발용)
+            .csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**", "/api/users/**"))
+
+            .headers(headers -> headers.frameOptions(FrameOptionsConfig::sameOrigin))
+
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/h2-console/**",
+                    "/",
+                    "/index.html", "logo_symbol.svg", "vite.svg",
+                    "/error",
+                    "/favicon.ico",
+                    "/assets/**",
+                    "/static/**",
+                    "/swagger-ui/**", "/v3/api-docs/**",
+                    "/api/users").permitAll()
+                .anyRequest().authenticated()
+            );
+
+        return http.build();
     }
 }

--- a/src/main/java/com/onepiece/otboo/infra/security/config/SecurityConfig.java
+++ b/src/main/java/com/onepiece/otboo/infra/security/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.onepiece.otboo.infra.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
@@ -78,9 +78,9 @@ class UserControllerTest {
     }
 
     @Test
-    void 이름을_100자_넘게_입력시_400_에러를_반환한다() throws Exception {
+    void 이름을_20자_넘게_입력시_400_에러를_반환한다() throws Exception {
         // given
-        String longName = "a".repeat(101);
+        String longName = "a".repeat(21);
 
         UserCreateRequest invalidRequest = new UserCreateRequest(longName, "aa@aa.com",
             "pwd1234@");

--- a/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
@@ -42,12 +42,13 @@ class UserControllerTest {
     void 회원가입_성공시_201을_반환한다() throws Exception {
         // given
         UserCreateRequest userCreateRequest = new UserCreateRequest("test", "test@test.com",
-            "test1234");
+            "test1234@");
 
         UserDto userDto = UserDto.builder()
             .id(UUID.randomUUID())
             .createdAt(Instant.now())
             .email("test@test.com")
+            .name("test")
             .role(Role.USER)
             .linkedOAuthProviders(List.of(Provider.LOCAL))
             .locked(false)
@@ -67,7 +68,7 @@ class UserControllerTest {
         verify(userService).create(argThat(req ->
             req.name().equals("test") &&
             req.email().equals("test@test.com") &&
-            req.password().equals("password")));
+            req.password().equals("test1234@")));
     }
 
     @Test
@@ -76,7 +77,7 @@ class UserControllerTest {
         String longName = "a".repeat(101);
 
         UserCreateRequest invalidRequest = new UserCreateRequest(longName, "aa@aa.com",
-            "pwd1234");
+            "pwd1234@");
 
         // when
         ResultActions result = mockMvc.perform(post("/api/users")
@@ -93,7 +94,7 @@ class UserControllerTest {
         String invalidEmail = "test#test.com";
 
         UserCreateRequest invalidRequest = new UserCreateRequest("test", invalidEmail,
-            "test1234");
+            "test1234@");
 
         // when
         ResultActions result = mockMvc.perform(post("/api/users")
@@ -117,16 +118,16 @@ class UserControllerTest {
         for (String pwd : invalidPasswords) {
             String invalidRequest = String.format("""
                     {
-                        "name": "test",
-                        "email": "test@test.com",
-                        "password": "%s"
+                      "name": "test",
+                      "email": "test@test.coom",
+                      "password": "%s"
                     }
                 """, pwd);
 
             // when
             ResultActions result = mockMvc.perform(post("/api/users")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(invalidRequest)));
+                .content(invalidRequest));
 
             // then
             result.andExpect(status().isBadRequest());

--- a/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,135 @@
+package com.onepiece.otboo.domain.user.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
+import com.onepiece.otboo.domain.user.dto.response.UserDto;
+import com.onepiece.otboo.domain.user.enums.Provider;
+import com.onepiece.otboo.domain.user.enums.Role;
+import com.onepiece.otboo.domain.user.service.UserService;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 회원가입_성공시_201을_반환한다() throws Exception {
+        // given
+        UserCreateRequest userCreateRequest = new UserCreateRequest("test", "test@test.com",
+            "test1234");
+
+        UserDto userDto = UserDto.builder()
+            .id(UUID.randomUUID())
+            .createdAt(Instant.now())
+            .email("test@test.com")
+            .role(Role.USER)
+            .linkedOAuthProviders(List.of(Provider.LOCAL))
+            .locked(false)
+            .build();
+
+        given(userService.create(any(UserCreateRequest.class))).willReturn(userDto);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userCreateRequest)));
+
+        // then
+        result.andExpect(status().isCreated())
+            .andExpect(jsonPath("$.name").value("test"))
+            .andExpect(jsonPath(("$.email")).value("test@test.com"));
+        verify(userService).create(argThat(req ->
+            req.name().equals("test") &&
+            req.email().equals("test@test.com") &&
+            req.password().equals("password")));
+    }
+
+    @Test
+    void 이름을_100자_넘게_입력시_400_에러를_반환한다() throws Exception {
+        // given
+        String longName = "a".repeat(101);
+
+        UserCreateRequest invalidRequest = new UserCreateRequest(longName, "aa@aa.com",
+            "pwd1234");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(invalidRequest)));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 올바르지_않은_형식의_이메일로_회원가입_요청시_400_에러를_반환한다() throws Exception {
+        // given
+        String invalidEmail = "test#test.com";
+
+        UserCreateRequest invalidRequest = new UserCreateRequest("test", invalidEmail,
+            "test1234");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(invalidRequest)));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 올바르지_않은_형식의_비밀번호로_회원가입_요청시_400_에러를_반환한다() throws Exception {
+        // given
+        List<String> invalidPasswords = List.of(
+            "123456", // 영어, 숫자, 특수문자 포함 조건 위반
+            "qwer111",
+            "2313@@",
+            "q12@" // 6자 이상 조건 위반
+        );
+
+        for (String pwd : invalidPasswords) {
+            String invalidRequest = String.format("""
+                    {
+                        "name": "test",
+                        "email": "test@test.com",
+                        "password": "%s"
+                    }
+                """, pwd);
+
+            // when
+            ResultActions result = mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidRequest)));
+
+            // then
+            result.andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
@@ -1,6 +1,5 @@
 package com.onepiece.otboo.domain.user.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
@@ -15,18 +14,25 @@ import com.onepiece.otboo.domain.user.dto.response.UserDto;
 import com.onepiece.otboo.domain.user.enums.Provider;
 import com.onepiece.otboo.domain.user.enums.Role;
 import com.onepiece.otboo.domain.user.service.UserService;
+import com.onepiece.otboo.global.config.JpaConfig;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-@WebMvcTest(UserController.class)
+@WebMvcTest(value = UserController.class,
+    excludeAutoConfiguration = {JpaConfig.class}
+)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("UserController 단위 테스트")
 class UserControllerTest {
 
     @Autowired
@@ -58,8 +64,8 @@ class UserControllerTest {
 
         // when
         ResultActions result = mockMvc.perform(post("/api/users")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(userCreateRequest)));
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(userCreateRequest)));
 
         // then
         result.andExpect(status().isCreated())
@@ -67,8 +73,8 @@ class UserControllerTest {
             .andExpect(jsonPath(("$.email")).value("test@test.com"));
         verify(userService).create(argThat(req ->
             req.name().equals("test") &&
-            req.email().equals("test@test.com") &&
-            req.password().equals("test1234@")));
+                req.email().equals("test@test.com") &&
+                req.password().equals("test1234@")));
     }
 
     @Test


### PR DESCRIPTION
📌 작업 개요

- 사용자 등록(회원가입) 기능 구현

✅ 완료한 작업

 - 사용자 등록(회원가입) 기능 구현
 - 사용자 등록(회원가입) Controller, Service 단위 테스트 추가
 - Spring Security 의존성 추가

🧪 테스트 결과

 - 로컬 테스트 완료
 - Postman 테스트 완료
 
<img width="1439" height="440" alt="image" src="https://github.com/user-attachments/assets/0a58a6de-dd04-4174-b199-58e35ef8dfb5" />
<img width="1439" height="440" alt="image" src="https://github.com/user-attachments/assets/df15d104-3259-4164-9d1c-20ef9fb0c72c" />


⚠️ 기타 참고 사항

 - 회원가입 시 `BcryptPasswordEncoder`를 사용하기 위해 간단하게 SecurityConfig 설정을 해놨는데 재구님이 올려주신 pr 머지되면 반영해서 수정해놓겠습니다!
 - `Controller` 단위 테스트를 위해 JpaConfig를 간단히 추가했습니다.

Related Issue #3 

Closes #3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 사용자 회원가입 API 추가 (POST /api/users): 이름/이메일/비밀번호 검증, 중복 이메일 처리, 응답에 이름 포함

- **Security**
  - 기본 보안 구성 적용: 공개 경로 허용(H2 콘솔/문서/회원가입), CSRF/프레임 옵션 설정, 비밀번호 해싱(BCrypt) 적용

- **Configuration**
  - JPA 감사 기능 활성화(테스트 제외)

- **Refactor**
  - 서비스·리포지토리·매퍼 구조 정비 및 DTO에 이름 필드 추가

- **Tests**
  - 회원가입 컨트롤러·서비스 단위 테스트 추가(성공/유효성/중복 이메일)

- **Chores**
  - Spring Security 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->