### PR TITLE
Chore/logging/35

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
 

--- a/src/main/java/com/onepiece/otboo/domain/weather/repository/WeatherRepository.java
+++ b/src/main/java/com/onepiece/otboo/domain/weather/repository/WeatherRepository.java
@@ -1,0 +1,11 @@
+package com.onepiece.otboo.domain.weather.repository;
+
+import com.onepiece.otboo.domain.weather.entity.Weather;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WeatherRepository extends JpaRepository<Weather, UUID> {
+
+}

--- a/src/main/java/com/onepiece/otboo/global/aop/Aop.java
+++ b/src/main/java/com/onepiece/otboo/global/aop/Aop.java
@@ -1,5 +1,0 @@
-package com.onepiece.otboo.global.aop;
-
-public class Aop {
-
-}

--- a/src/main/java/com/onepiece/otboo/global/aop/LoggingAspect.java
+++ b/src/main/java/com/onepiece/otboo/global/aop/LoggingAspect.java
@@ -1,0 +1,156 @@
+package com.onepiece.otboo.global.aop;
+
+import java.util.Arrays;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * AOP 기반 계층별 로깅 Aspect
+ * <p>
+ * 컨트롤러/서비스/리포지토리 계층의 주요 메서드 실행 전후, 예외 발생 시 구조화 로그를 남긴다. requestId, 계층, 클래스, 메서드, 실행 시간, 예외 정보 등을
+ * 포함한다.
+ */
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+
+    /**
+     * 컨트롤러 계층의 모든 메서드에 대한 포인트컷
+     */
+    @Pointcut("execution(* com.onepiece.otboo..controller..*(..))")
+    public void controllerLayer() {
+    }
+
+
+    /**
+     * 서비스 계층의 모든 메서드에 대한 포인트컷
+     */
+    @Pointcut("execution(* com.onepiece.otboo..service..*(..))")
+    public void serviceLayer() {
+    }
+
+
+    /**
+     * 리포지토리 계층의 모든 메서드에 대한 포인트컷
+     */
+    @Pointcut("execution(* com.onepiece.otboo..repository..*(..))")
+    public void repositoryLayer() {
+    }
+
+
+    /**
+     * 계층별 메서드 실행 시간 및 성능 경고
+     */
+    @Around("controllerLayer() || serviceLayer() || repositoryLayer()")
+    public Object logExecutionTime(ProceedingJoinPoint pjp) throws Throwable {
+        String layer = resolveLayer(pjp);
+        String className = pjp.getSignature().getDeclaringTypeName();
+        String methodName = pjp.getSignature().getName();
+        String requestId = ensureRequestId();
+        long startTime = System.currentTimeMillis();
+        try {
+            Object result = pjp.proceed();
+            long endTime = System.currentTimeMillis();
+            long executionTime = endTime - startTime;
+            log.info("[{}] {}#{} 실행 시간: {}ms (requestId: {})", layer, className, methodName,
+                executionTime, requestId);
+            if (executionTime > 1000) {
+                log.warn(
+                    "[ExecutionTime] [{}] {}#{} 실행 시간이 {}ms로 느립니다. 성능 최적화가 필요합니다. (requestId: {})",
+                    layer, className, methodName, executionTime, requestId);
+            }
+            return result;
+        } catch (Throwable throwable) {
+            long endTime = System.currentTimeMillis();
+            long executionTime = endTime - startTime;
+            log.error("[{}] {}#{} 실행 실패 - 실행 시간: {}ms, 예외: {} (requestId: {})", layer, className,
+                methodName, executionTime, throwable.getMessage(), requestId);
+            throw throwable;
+        }
+    }
+
+    /**
+     * 메서드 실행 전에 로그를 기록한다. (매개변수)
+     */
+    @Before("controllerLayer() || serviceLayer() || repositoryLayer()")
+    public void logBefore(JoinPoint joinPoint) {
+        String layer = resolveLayer((ProceedingJoinPoint) joinPoint);
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String methodName = joinPoint.getSignature().getName();
+        Object[] args = joinPoint.getArgs();
+        String requestId = ensureRequestId();
+        log.info("==> [{}] {}#{} 실행 시작 - requestId: {}, 매개변수: {}", layer, className, methodName,
+            requestId, Arrays.toString(args));
+    }
+
+    /**
+     * 메서드 정상 실행 후에 로그를 기록한다. (반환값)
+     */
+    @AfterReturning(pointcut = "controllerLayer() || serviceLayer() || repositoryLayer()", returning = "result")
+    public void logAfterReturning(JoinPoint joinPoint, Object result) {
+        String layer = resolveLayer((ProceedingJoinPoint) joinPoint);
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String methodName = joinPoint.getSignature().getName();
+        String requestId = ensureRequestId();
+        log.info("<== [{}] {}#{} 실행 완료 - requestId: {}, 반환값: {}", layer, className, methodName,
+            requestId, result);
+    }
+
+    /**
+     * 메서드 실행 중 예외 발생 시 로그를 기록한다.
+     */
+    @AfterThrowing(pointcut = "controllerLayer() || serviceLayer() || repositoryLayer()", throwing = "exception")
+    public void logAfterThrowing(JoinPoint joinPoint, Exception exception) {
+        String layer = resolveLayer((ProceedingJoinPoint) joinPoint);
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String methodName = joinPoint.getSignature().getName();
+        String requestId = ensureRequestId();
+        log.error("!!! [{}] {}#{} 실행 중 예외 발생 - requestId: {}, 예외: {}, 메시지: {}", layer, className,
+            methodName, requestId, exception.getClass().getSimpleName(), exception.getMessage());
+    }
+
+
+    /**
+     * 클래스명에 따라 계층(controller/service/repository) 문자열 반환
+     */
+    private String resolveLayer(ProceedingJoinPoint pjp) {
+        String typeName = pjp.getSignature().getDeclaringTypeName();
+        if (typeName.contains(".controller.")) {
+            return "controller";
+        }
+        if (typeName.contains(".service.")) {
+            return "service";
+        }
+        if (typeName.contains(".repository.")) {
+            return "repository";
+        }
+        return "unknown";
+    }
+
+
+    /**
+     * MDC에 requestId가 없으면 새로 생성하여 저장, 반환
+     */
+    private String ensureRequestId() {
+        String requestId = MDC.get("requestId");
+        if (requestId == null || requestId.isBlank()) {
+            requestId = UUID.randomUUID().toString();
+            MDC.put("requestId", requestId);
+        }
+        return requestId;
+    }
+}
+

--- a/src/main/java/com/onepiece/otboo/global/logging/HttpLoggingFilter.java
+++ b/src/main/java/com/onepiece/otboo/global/logging/HttpLoggingFilter.java
@@ -1,0 +1,42 @@
+package com.onepiece.otboo.global.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@Order(1)
+public class HttpLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        long start = System.currentTimeMillis();
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long elapsed = System.currentTimeMillis() - start;
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("requestId", MDC.get(MdcLoggingFilter.MDC_REQUEST_ID));
+            payload.put("path", MDC.get(MdcLoggingFilter.MDC_PATH));
+            payload.put("userId", MDC.get(MdcLoggingFilter.MDC_USER_ID));
+            payload.put("status", response.getStatus());
+            payload.put("elapsedMs", elapsed);
+            log.info("[HttpLoggingFilter] {}", payload);
+        }
+    }
+}
+

--- a/src/main/java/com/onepiece/otboo/global/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/onepiece/otboo/global/logging/MdcLoggingFilter.java
@@ -1,0 +1,52 @@
+package com.onepiece.otboo.global.logging;
+
+import com.onepiece.otboo.infra.security.userdetails.CustomUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(0)
+public class MdcLoggingFilter extends OncePerRequestFilter {
+
+    public static final String MDC_REQUEST_ID = "requestId";
+    public static final String MDC_USER_ID = "userId";
+    public static final String MDC_PATH = "path";
+    public static final String HEADER_REQUEST_ID = "X-Request-Id";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String requestId = Optional.ofNullable(request.getHeader(HEADER_REQUEST_ID))
+                .filter(s -> !s.isBlank())
+                .orElse(UUID.randomUUID().toString());
+            MDC.put(MDC_REQUEST_ID, requestId);
+            MDC.put(MDC_PATH, request.getMethod() + " " + request.getRequestURI());
+
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null && auth.isAuthenticated()
+                && auth.getPrincipal() instanceof CustomUserDetails cud) {
+                MDC.put(MDC_USER_ID, String.valueOf(cud.getUserId()));
+            }
+
+            response.addHeader(HEADER_REQUEST_ID, requestId);
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_REQUEST_ID);
+            MDC.remove(MDC_USER_ID);
+            MDC.remove(MDC_PATH);
+        }
+    }
+}
+

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    import: optional:file:.env[.properties]
+
+logging:
+  level:
+    root: info
+    com.onepiece.otboo: info
+    org.springframework: info
+    org.hibernate.SQL: warn

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,6 +18,13 @@ spring:
       enabled: true      # H2 Console 사용 여부
       path: /h2-console  # H2 Console 접속 주소
 
+logging:
+  level:
+    root: info
+    com.onepiece.otboo: info
+    org.springframework: info
+    org.hibernate.SQL: warn
+
 otboo:
   jwt:
     access-token:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <!-- 로그 레벨별 색상 설정 -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+
+    <property name="LOG_PATH" value="logs"/>
+    <!-- red, green, yellow, blue, magenta, cyan, white, faint, bold -->
+    <property name="LOG_PATTERN" value="%d{yy-MM-dd HH:mm:ss.SSS} [%clr(%thread){green}] %clr(%-5level) %clr(%-36logger{36}){cyan} [%clr(%X{requestId}){magenta} | %clr(%X{userId}){blue} | %clr(%X{path}){yellow}] - %msg%n"/>
+    <property name="LOG_PATTERN_FILE" value="%d{yy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %-36logger{36} [%X{requestId} | %X{userId} | %X{path}] - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+
+    <!-- main: info 이상 로그 파일 -->
+    <appender name="MAIN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/main.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/main.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN_FILE}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- debug: debug 레벨 로그 파일 -->
+    <appender name="DEBUG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/debug.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/debug.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN_FILE}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>DEBUG</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+    </appender>
+
+    <!-- trace: trace 레벨 로그 파일 -->
+    <appender name="TRACE_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/trace.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/trace.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN_FILE}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>TRACE</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+    </appender>
+
+    <!-- security-trace: trace 레벨 로그 파일 -->
+    <appender name="SECURITY_TRACE_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/security-trace.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/security-trace.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN_FILE}</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>TRACE</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+    </appender>
+
+
+    <root level="TRACE">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="MAIN_FILE"/>
+        <appender-ref ref="DEBUG_FILE"/>
+        <appender-ref ref="TRACE_FILE"/>
+        <appender-ref ref="SECURITY_TRACE_FILE"/>
+    </root>
+
+    <logger name="com.onepiece.otboo" level="DEBUG">
+        <appender-ref ref="DEBUG_FILE"/>
+    </logger>
+
+    <logger name="com.onepiece.otboo" level="TRACE">
+        <appender-ref ref="TRACE_FILE"/>
+    </logger>
+
+    <!-- Spring Security 관련 TRACE 로그 파일 기록 -->
+    <logger name="org.springframework.security" level="TRACE">
+        <appender-ref ref="SECURITY_TRACE_FILE"/>
+    </logger>
+
+</configuration>


### PR DESCRIPTION
## 📌 작업 개요

- 로그 기본 구성, 이후 필요 시 추가 구성
- AOP(Aspect Oriented Programming)를 활용하여 컨트롤러/서비스/리포지토리 계층의 주요 메서드 호출을 자동으로 로깅
- 요청/응답/예외 로그를 구조화(JSON 등)하여 저장
- 로그 파일을 일별 또는 용량 기준으로 분리(rolling) 관리

## ✅ 완료한 작업

1. **AOP 로깅 구현**
    - [x] 컨트롤러, 서비스, 리포지토리 계층의 주요 메서드에 대해 `@Around` 어드바이스 적용
    - [x] 메서드 실행 전/후, 예외 발생 시 로그 기록
2. **로그 구조화 및 저장**
    - [x] 로그에 요청 ID, 사용자 ID 등 MDC(Mapped Diagnostic Context) 정보 포함
3. **로그 파일 관리**
    - [x] `logback-spring.xml`에서 `RollingFileAppender` 설정
        - 일 단위 및 파일 크기, 전체 용량 기준으로 로그 파일 분리(rolling)
    - [x] 로그 파일이 지정된 경로에 정상적으로 생성 및 분리되는지 확인
        - main 파일: info 이상만 기록
        - debug 파일: debug 레벨만 기록
        - trace 파일: trace 이하만 기록 (trace만 별도 분리)
4. **환경별 로그 레벨 분리**
    - [x] 개발 환경: DEBUG 레벨 로그 활성화
    - [x] 운영 환경: INFO 이상 로그 기록, 예외는 ERROR 레벨로 기록

## 🧪 테스트 결과

<img width="2412" height="1078" alt="Capture_2025-09-16_01-30-05" src="https://github.com/user-attachments/assets/0c8ac988-f407-4915-879e-77815031379e" />

- [x] 주요 계층의 메서드 호출 시 로그가 정상적으로 남는지 확인
- [x] 예외 발생 시 ERROR 로그가 남는지 확인
- [x] MDC 정보가 로그에 포함되는지 확인
- [x] 로그 파일이 rolling 정책에 따라 분리되는지 확인

## ⚠️ 기타 참고 사항

- 스키마 변경에 의한 DataSeeder 수정도 일부 포함되어 있습니다.

---

## Related Issue

Closes #35 
