### PR TITLE
[Feature] 피드 등록 API/서비스 구현 및 테스트

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/controller/FeedController.java
@@ -1,5 +1,6 @@
 package com.onepiece.otboo.domain.feed.controller;
 
+import com.onepiece.otboo.domain.feed.controller.api.FeedApi;
 import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
 import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
 import com.onepiece.otboo.domain.feed.service.FeedService;
@@ -13,7 +14,7 @@ import java.net.URI;
 @RestController
 @RequestMapping("/api/feeds")
 @RequiredArgsConstructor
-public class FeedController {
+public class FeedController implements FeedApi {
     private final FeedService feedService;
 
     @PostMapping

--- a/src/main/java/com/onepiece/otboo/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/controller/FeedController.java
@@ -1,0 +1,25 @@
+package com.onepiece.otboo.domain.feed.controller;
+
+import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
+import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
+import com.onepiece.otboo.domain.feed.service.FeedService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/feeds")
+@RequiredArgsConstructor
+public class FeedController {
+    private final FeedService feedService;
+
+    @PostMapping
+    public ResponseEntity<FeedResponse> createFeed(@Valid @RequestBody FeedCreateRequest req) {
+        FeedResponse res = feedService.create(req);
+        return ResponseEntity.created(URI.create("/api/feeds/" + res.id())).body(res);
+    }
+
+}

--- a/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
@@ -40,6 +40,7 @@ public interface FeedApi {
             responseCode = "400",
             description = "유효하지 않은 요청(필드 검증 실패/중복 등)",
             content = @Content(
+                mediaType = "application/json",
                 schema = @Schema(implementation = ErrorResponse.class
             ))
         ),
@@ -47,6 +48,7 @@ public interface FeedApi {
             responseCode = "403",
             description = "권한 부족/소유권 불일치",
             content = @Content(
+                mediaType = "application/json",
                 schema = @Schema(implementation = ErrorResponse.class
             ))
         ),
@@ -54,6 +56,7 @@ public interface FeedApi {
             responseCode = "404",
             description = "관련 자원(사용자/의상/날씨) 없음",
             content = @Content(
+                mediaType = "application/json",
                 schema = @Schema(implementation = ErrorResponse.class
             ))
         )

--- a/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,7 @@ public interface FeedApi {
         summary = "피드 등록",
         description = "작성자가 선택한 옷 조합과 내용으로 피드를 등록합니다."
     )
+    @SecurityRequirement(name = "bearerAuth")
     @ApiResponses({
         @ApiResponse(
             responseCode = "201",
@@ -42,6 +44,13 @@ public interface FeedApi {
             content = @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ErrorResponse.class
+            ))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 실패(미인증/만료/무효 토큰)",
+            content = @Content(
+            schema = @Schema(implementation = ErrorResponse.class
             ))
         ),
         @ApiResponse(

--- a/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
@@ -2,18 +2,18 @@ package com.onepiece.otboo.domain.feed.controller.api;
 
 import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
 import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
+import com.onepiece.otboo.global.dto.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import com.onepiece.otboo.global.dto.response.ErrorResponse;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "피드 관리", description = "피드 관련 API")
 public interface FeedApi {

--- a/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
@@ -1,0 +1,63 @@
+package com.onepiece.otboo.domain.feed.controller.api;
+
+import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
+import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import com.onepiece.otboo.global.dto.response.ErrorResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "피드 관리", description = "피드 관련 API")
+public interface FeedApi {
+
+    @Operation(
+        summary = "피드 등록",
+        description = "작성자가 선택한 옷 조합과 내용으로 피드를 등록합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "피드 등록 성공",
+            headers = @Header(
+                name = "Location",
+                description = "생성된 리소스의 URI",
+                schema = @Schema(type = "string", example = "/api/feeds/{id}")
+            ),
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = FeedResponse.class
+                ))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "유효하지 않은 요청(필드 검증 실패/중복 등)",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class
+            ))
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "권한 부족/소유권 불일치",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class
+            ))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "관련 자원(사용자/의상/날씨) 없음",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class
+            ))
+        )
+    })
+    @PostMapping(consumes = "application/json", produces = "application/json")
+    ResponseEntity<FeedResponse> createFeed(@Valid @RequestBody FeedCreateRequest feedCreateRequest);
+}

--- a/src/main/java/com/onepiece/otboo/domain/feed/dto/request/FeedCreateRequest.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/dto/request/FeedCreateRequest.java
@@ -3,16 +3,24 @@ package com.onepiece.otboo.domain.feed.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 public record FeedCreateRequest(
-    @NotNull UUID authorId,
-    @NotNull UUID weatherId,
-    @NotEmpty List<UUID> clothesIds,
-    @NotBlank String content
+    @NotNull
+    UUID authorId,
+
+    UUID weatherId,
+
+    @NotEmpty
+    List<UUID> clothesIds,
+
+    @NotBlank
+    @Size(max = 1000)
+    String content
 ) {
     public List<UUID> distinctClothesIds() {
         return List.copyOf(Set.copyOf(clothesIds));

--- a/src/main/java/com/onepiece/otboo/domain/feed/mapper/FeedMapper.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/mapper/FeedMapper.java
@@ -27,7 +27,7 @@ public interface FeedMapper {
     @Mapping(target = "likedByMe", source = "likedByMe")
     FeedResponse toResponse(Feed feed,
                             AuthorDto author,
-                            com.onepiece.otboo.domain.weather.dto.response.WeatherSummaryDto weather,
+                            WeatherSummaryDto weather,
                             List<OotdDto> ootds,
                             boolean likedByMe);
 

--- a/src/main/java/com/onepiece/otboo/domain/feed/mapper/FeedMapper.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/mapper/FeedMapper.java
@@ -1,0 +1,34 @@
+package com.onepiece.otboo.domain.feed.mapper;
+
+import com.onepiece.otboo.domain.feed.dto.response.AuthorDto;
+import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
+import com.onepiece.otboo.domain.feed.dto.response.OotdDto;
+import com.onepiece.otboo.domain.feed.entity.Feed;
+import com.onepiece.otboo.domain.weather.dto.response.WeatherSummaryDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface FeedMapper {
+
+    @Mapping(target = "author",  ignore = true)
+    @Mapping(target = "weather", ignore = true)
+    @Mapping(target = "ootds",   expression = "java(java.util.List.of())")
+    @Mapping(target = "likedByMe", constant = "false")
+    FeedResponse toResponse(Feed feed);
+
+
+    @Mapping(target = "author",  source = "author")
+    @Mapping(target = "weather", source = "weather")
+    @Mapping(target = "ootds",   source = "ootds")
+    @Mapping(target = "likedByMe", source = "likedByMe")
+    FeedResponse toResponse(Feed feed,
+                            AuthorDto author,
+                            com.onepiece.otboo.domain.weather.dto.response.WeatherSummaryDto weather,
+                            List<OotdDto> ootds,
+                            boolean likedByMe);
+
+}

--- a/src/main/java/com/onepiece/otboo/domain/feed/service/FeedService.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/service/FeedService.java
@@ -8,9 +8,10 @@ import com.onepiece.otboo.domain.feed.mapper.FeedMapper;
 import com.onepiece.otboo.domain.feed.repository.FeedRepository;
 import com.onepiece.otboo.domain.user.entity.User;
 import com.onepiece.otboo.domain.user.repository.UserRepository;
-import com.onepiece.otboo.domain.weather.dto.response.WeatherSummaryDto;
 import com.onepiece.otboo.domain.weather.entity.Weather;
 import com.onepiece.otboo.domain.weather.repository.WeatherRepository;
+import com.onepiece.otboo.global.exception.ErrorCode;
+import com.onepiece.otboo.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,19 +33,11 @@ public class FeedService {
     @Transactional
     public FeedResponse create(FeedCreateRequest r) {
         User authorEntity = userRepository.findById(r.authorId())
-            .orElseThrow(() -> new IllegalArgumentException("author not found"));
+            .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
 
-        WeatherSummaryDto weatherDto = null;
         if (r.weatherId() != null) {
             Weather weather = weatherRepository.findById(r.weatherId())
-                .orElseThrow(() -> new IllegalArgumentException("weather not found"));
-
-            weatherDto = new WeatherSummaryDto(
-                weather.getId(),
-                weather.getSkyStatus(),
-                null,
-                null
-            );
+                .orElseThrow(() -> new GlobalException(ErrorCode.WEATHER_NOT_FOUND));
         }
 
         var dedup = new HashSet<>(r.clothesIds());

--- a/src/main/java/com/onepiece/otboo/domain/feed/service/FeedService.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/service/FeedService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -40,6 +41,7 @@ public class FeedService {
                 .orElseThrow(() -> new GlobalException(ErrorCode.WEATHER_NOT_FOUND));
         }
 
+        List<UUID> clothes = r.clothesIds() == null ? List.of() : r.clothesIds();
         var dedup = new HashSet<>(r.clothesIds());
 
         // TODO: Clothes 모듈 연동 후 소유권 검증 로직 복구

--- a/src/main/java/com/onepiece/otboo/domain/feed/service/FeedService.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/service/FeedService.java
@@ -1,0 +1,77 @@
+package com.onepiece.otboo.domain.feed.service;
+
+import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
+import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
+import com.onepiece.otboo.domain.feed.entity.Feed;
+import com.onepiece.otboo.domain.feed.entity.FeedClothes;
+import com.onepiece.otboo.domain.feed.mapper.FeedMapper;
+import com.onepiece.otboo.domain.feed.repository.FeedRepository;
+import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.domain.user.repository.UserRepository;
+import com.onepiece.otboo.domain.weather.dto.response.WeatherSummaryDto;
+import com.onepiece.otboo.domain.weather.entity.Weather;
+import com.onepiece.otboo.domain.weather.repository.WeatherRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class FeedService {
+
+    private final FeedRepository feedRepository;
+    private final FeedMapper feedMapper;
+
+    private final UserRepository userRepository;
+    private final WeatherRepository weatherRepository;
+//    private final ClothesRepository clothesRepository;
+
+    @Transactional
+    public FeedResponse create(FeedCreateRequest r) {
+        User authorEntity = userRepository.findById(r.authorId())
+            .orElseThrow(() -> new IllegalArgumentException("author not found"));
+
+        WeatherSummaryDto weatherDto = null;
+        if (r.weatherId() != null) {
+            Weather weather = weatherRepository.findById(r.weatherId())
+                .orElseThrow(() -> new IllegalArgumentException("weather not found"));
+
+            weatherDto = new WeatherSummaryDto(
+                weather.getId(),
+                weather.getSkyStatus(),
+                null,
+                null
+            );
+        }
+
+        var dedup = new HashSet<>(r.clothesIds());
+
+        // TODO: Clothes 모듈 연동 후 소유권 검증 로직 복구
+        //long owned = clothesRepository.countByIdInAndOwnerId(dedup, r.authorId());
+        //if (owned != dedup.size())
+        //    throw new IllegalArgumentException("clothes ownership mismatch");
+
+        Feed feed = Feed.builder()
+            .authorId(r.authorId())
+            .weatherId(r.weatherId())
+            .content(r.content())
+            .likeCount(0L)
+            .commentCount(0L)
+            .build();
+
+        for (UUID clothesId : dedup) {
+            FeedClothes link = FeedClothes.builder()
+                .clothesId(clothesId)
+                .build();
+            link.setFeed(feed);
+            feed.getFeedClothes().add(link);
+        }
+
+        Feed saved = feedRepository.save(feed);
+
+        return feedMapper.toResponse(saved);
+    }
+}

--- a/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 확인 실패", "존재하지 않는 사용자입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일", "이미 존재하는 이메일입니다."),
 
+    // Weather
+    WEATHER_NOT_FOUND(HttpStatus.NOT_FOUND, "날씨 확인 실패", "날씨 정보를 찾을 수 없습니다."),
+
     // AUTH
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 올바르지 않습니다.", "아이디 또는 비밀번호를 확인해 주세요."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.", "이 리소스에 접근할 권한이 없습니다."),
@@ -26,6 +29,10 @@ public enum ErrorCode {
     TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "토큰 처리 중 에러가 발생했습니다.", "다시 로그인해 주세요."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.", "다시 로그인해 주세요."),
 
+    // FEED
+    FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "피드 확인 실패", "피드를 찾을 수 없습니다."),
+    FEED_FORBIDDEN(HttpStatus.FORBIDDEN, "피드 권한 없음", "해당 피드에 접근/수정/삭제 권한이 없습니다."),
+    FEED_GONE(HttpStatus.GONE, "삭제된 피드", "이미 삭제된 피드입니다."),
 
     // LOCATION
     INVALID_COORDINATE(HttpStatus.BAD_REQUEST, "유효하지 않은 좌표 값입니다.", "위도와 경도를 확인해주세요."),

--- a/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
@@ -60,26 +60,4 @@ class FeedControllerTest {
             .andExpect(status().isCreated())
             .andExpect(header().string("Location", "/api/feeds/" + id));
     }
-
-    @Test
-    @WithMockUser
-    void createFeed_returns400_whenWeatherIdNull() throws Exception {
-        var body = new FeedCreateRequest(
-            UUID.randomUUID(),
-            null,
-            List.of(UUID.randomUUID()),
-            "content"
-        );
-
-        mockMvc.perform(
-                post("/api/feeds")
-                    .with(csrf())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(body))
-            )
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.exceptionName").value("MethodArgumentNotValidException"))
-            .andExpect(jsonPath("$.details.validationError", containsString("weatherId")))
-            .andExpect(jsonPath("$.details.validationError", containsString("must not be null")));
-    }
 }

--- a/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
@@ -8,13 +8,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import static org.hamcrest.Matchers.containsString;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.UUID;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = FeedController.class)
 class FeedControllerTest {
@@ -22,11 +26,11 @@ class FeedControllerTest {
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
 
-    @org.springframework.test.context.bean.override.mockito.MockitoBean
+    @MockitoBean
     FeedService feedService;
 
     @Test
-    @org.springframework.security.test.context.support.WithMockUser
+    @WithMockUser
     void createFeed_returns201_withLocationHeader() throws Exception {
         UUID id = UUID.randomUUID();
 
@@ -53,7 +57,7 @@ class FeedControllerTest {
     }
 
     @Test
-    @org.springframework.security.test.context.support.WithMockUser
+    @WithMockUser
     void createFeed_returns400_whenWeatherIdNull() throws Exception {
         var body = new FeedCreateRequest(
             UUID.randomUUID(),

--- a/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
@@ -13,8 +13,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.hamcrest.Matchers.containsString;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.util.List;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -34,21 +39,21 @@ class FeedControllerTest {
     void createFeed_returns201_withLocationHeader() throws Exception {
         UUID id = UUID.randomUUID();
 
-        FeedResponse mocked = org.mockito.Mockito.mock(FeedResponse.class);
-        org.mockito.Mockito.when(mocked.id()).thenReturn(id);
-        org.mockito.Mockito.when(feedService.create(org.mockito.ArgumentMatchers.any(FeedCreateRequest.class)))
+        FeedResponse mocked = mock(FeedResponse.class);
+        when(mocked.id()).thenReturn(id);
+        when(feedService.create(any(FeedCreateRequest.class)))
             .thenReturn(mocked);
 
         var body = new FeedCreateRequest(
             UUID.randomUUID(),
             UUID.randomUUID(),
-            java.util.List.of(UUID.randomUUID()),
+            List.of(UUID.randomUUID()),
             "content"
         );
 
         mockMvc.perform(
                 post("/api/feeds")
-                    .with(org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf())
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(body))
             )
@@ -62,13 +67,13 @@ class FeedControllerTest {
         var body = new FeedCreateRequest(
             UUID.randomUUID(),
             null,
-            java.util.List.of(UUID.randomUUID()),
+            List.of(UUID.randomUUID()),
             "content"
         );
 
         mockMvc.perform(
                 post("/api/feeds")
-                    .with(org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf())
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(body))
             )
@@ -78,4 +83,3 @@ class FeedControllerTest {
             .andExpect(jsonPath("$.details.validationError", containsString("must not be null")));
     }
 }
-

--- a/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
@@ -1,0 +1,77 @@
+package com.onepiece.otboo.domain.feed.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
+import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
+import com.onepiece.otboo.domain.feed.service.FeedService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = FeedController.class)
+class FeedControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @org.springframework.test.context.bean.override.mockito.MockitoBean
+    FeedService feedService;
+
+    @Test
+    @org.springframework.security.test.context.support.WithMockUser
+    void createFeed_returns201_withLocationHeader() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        FeedResponse mocked = org.mockito.Mockito.mock(FeedResponse.class);
+        org.mockito.Mockito.when(mocked.id()).thenReturn(id);
+        org.mockito.Mockito.when(feedService.create(org.mockito.ArgumentMatchers.any(FeedCreateRequest.class)))
+            .thenReturn(mocked);
+
+        var body = new FeedCreateRequest(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            java.util.List.of(UUID.randomUUID()),
+            "content"
+        );
+
+        mockMvc.perform(
+                post("/api/feeds")
+                    .with(org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(body))
+            )
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", "/api/feeds/" + id));
+    }
+
+    @Test
+    @org.springframework.security.test.context.support.WithMockUser
+    void createFeed_returns400_whenWeatherIdNull() throws Exception {
+        var body = new FeedCreateRequest(
+            UUID.randomUUID(),
+            null,
+            java.util.List.of(UUID.randomUUID()),
+            "content"
+        );
+
+        mockMvc.perform(
+                post("/api/feeds")
+                    .with(org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(body))
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.exceptionName").value("MethodArgumentNotValidException"))
+            .andExpect(jsonPath("$.details.validationError", containsString("weatherId")))
+            .andExpect(jsonPath("$.details.validationError", containsString("must not be null")));
+    }
+}
+

--- a/src/test/java/com/onepiece/otboo/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/service/FeedServiceTest.java
@@ -1,0 +1,132 @@
+package com.onepiece.otboo.domain.feed.service;
+
+import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
+import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
+import com.onepiece.otboo.domain.feed.entity.Feed;
+import com.onepiece.otboo.domain.feed.entity.FeedClothes;
+import com.onepiece.otboo.domain.feed.mapper.FeedMapper;
+import com.onepiece.otboo.domain.feed.repository.FeedRepository;
+import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.domain.user.repository.UserRepository;
+import com.onepiece.otboo.domain.weather.entity.Weather;
+import com.onepiece.otboo.domain.weather.repository.WeatherRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedServiceTest {
+
+    @Mock FeedRepository feedRepository;
+    @Mock FeedMapper feedMapper;
+    @Mock UserRepository userRepository;
+    @Mock WeatherRepository weatherRepository;
+
+    @InjectMocks FeedService feedService;
+
+    @Captor ArgumentCaptor<Feed> feedCaptor;
+
+    UUID authorId;
+    UUID weatherId;
+    UUID c1; UUID c2;
+
+    @BeforeEach
+    void setUp() {
+        authorId = UUID.randomUUID();
+        weatherId = UUID.randomUUID();
+        c1 = UUID.randomUUID();
+        c2 = UUID.randomUUID();
+    }
+
+    @Test
+    void create_success_withWeather_and_dedupApplied() {
+        // given
+        var author = mock(User.class);
+        when(userRepository.findById(authorId)).thenReturn(Optional.of(author));
+
+        var weather = mock(Weather.class);
+        when(weatherRepository.findById(weatherId)).thenReturn(Optional.of(weather));
+
+        when(feedRepository.save(any(Feed.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(feedMapper.toResponse(any(Feed.class))).thenReturn(mock(FeedResponse.class));
+
+        var req = new FeedCreateRequest(
+            authorId,
+            weatherId,
+            List.of(c1, c2, c1),
+            "hello"
+        );
+
+        FeedResponse res = feedService.create(req);
+
+        assertThat(res).isNotNull();
+
+        verify(feedRepository).save(feedCaptor.capture());
+        Feed saved = feedCaptor.getValue();
+
+        List<FeedClothes> links = saved.getFeedClothes();
+        assertThat(links).hasSize(2);
+        assertThat(links.stream().map(FeedClothes::getClothesId)).containsExactlyInAnyOrder(c1, c2);
+
+        assertThat(saved.getLikeCount()).isZero();
+        assertThat(saved.getCommentCount()).isZero();
+
+        verify(feedMapper).toResponse(any(Feed.class));
+    }
+
+    @Test
+    void create_success_withoutWeather() {
+        when(userRepository.findById(authorId)).thenReturn(Optional.of(mock(User.class)));
+        when(feedRepository.save(any(Feed.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(feedMapper.toResponse(any(Feed.class))).thenReturn(mock(FeedResponse.class));
+
+        var req = new FeedCreateRequest(
+            authorId,
+            null,
+            List.of(),
+            "no weather"
+        );
+
+        FeedResponse res = feedService.create(req);
+
+        assertThat(res).isNotNull();
+        verify(weatherRepository, never()).findById(any());
+        verify(feedRepository).save(any(Feed.class));
+    }
+
+    @Test
+    void create_fail_authorNotFound() {
+        when(userRepository.findById(authorId)).thenReturn(Optional.empty());
+        var req = new FeedCreateRequest(authorId, null, List.of(c1), "x");
+
+        assertThatThrownBy(() -> feedService.create(req))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("author not found");
+
+        verify(feedRepository, never()).save(any());
+        verify(feedMapper, never()).toResponse(any());
+    }
+
+    @Test
+    void create_fail_weatherNotFound() {
+        when(userRepository.findById(authorId)).thenReturn(Optional.of(mock(User.class)));
+        when(weatherRepository.findById(weatherId)).thenReturn(Optional.empty());
+
+        var req = new FeedCreateRequest(authorId, weatherId, List.of(c1), "x");
+
+        assertThatThrownBy(() -> feedService.create(req))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("weather not found");
+
+        verify(feedRepository, never()).save(any());
+        verify(feedMapper, never()).toResponse(any());
+    }
+}

--- a/src/test/java/com/onepiece/otboo/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/service/FeedServiceTest.java
@@ -47,7 +47,7 @@ class FeedServiceTest {
     }
 
     @Test
-    void create_success_withWeather_and_dedupApplied() {
+    void 피드_등록_성공시_날씨가_연결되고_중복된_의상ID가_제거된다() {
         // given
         var author = mock(User.class);
         when(userRepository.findById(authorId)).thenReturn(Optional.of(author));
@@ -65,8 +65,10 @@ class FeedServiceTest {
             "hello"
         );
 
+        // when
         FeedResponse res = feedService.create(req);
 
+        // then
         assertThat(res).isNotNull();
 
         verify(feedRepository).save(feedCaptor.capture());
@@ -83,7 +85,8 @@ class FeedServiceTest {
     }
 
     @Test
-    void create_success_withoutWeather() {
+    void 피드_등록_성공시_날씨가_없어도_저장된다() {
+        // given
         when(userRepository.findById(authorId)).thenReturn(Optional.of(mock(User.class)));
         when(feedRepository.save(any(Feed.class))).thenAnswer(inv -> inv.getArgument(0));
         when(feedMapper.toResponse(any(Feed.class))).thenReturn(mock(FeedResponse.class));
@@ -95,18 +98,22 @@ class FeedServiceTest {
             "no weather"
         );
 
+        // when
         FeedResponse res = feedService.create(req);
 
+        // then
         assertThat(res).isNotNull();
         verify(weatherRepository, never()).findById(any());
         verify(feedRepository).save(any(Feed.class));
     }
 
     @Test
-    void create_fail_authorNotFound() {
+    void 피드_등록시_작성자를_찾지_못하면_실패한다() {
+        //given
         when(userRepository.findById(authorId)).thenReturn(Optional.empty());
         var req = new FeedCreateRequest(authorId, null, List.of(c1), "x");
 
+        // when & then
         assertThatThrownBy(() -> feedService.create(req))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("author not found");
@@ -116,12 +123,14 @@ class FeedServiceTest {
     }
 
     @Test
-    void create_fail_weatherNotFound() {
+    void 피드_등록시_날씨를_찾지_못하면_실패한다() {
+        // given
         when(userRepository.findById(authorId)).thenReturn(Optional.of(mock(User.class)));
         when(weatherRepository.findById(weatherId)).thenReturn(Optional.empty());
 
         var req = new FeedCreateRequest(authorId, weatherId, List.of(c1), "x");
 
+        // when & then
         assertThatThrownBy(() -> feedService.create(req))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("weather not found");


### PR DESCRIPTION
## 📌 작업 개요

-  등록 검증 로직, 컨트롤러, 테스트 구현

## ✅ 완료한 작업

- 등록 검증 로직, 컨트롤러, 테스트 구현

## 🧪 테스트 결과

- 로컬 테스트 완료

<img width="694" height="121" alt="image" src="https://github.com/user-attachments/assets/8d84f66e-61fc-47bd-a21b-8267be2b66d8" />
<img width="843" height="128" alt="image" src="https://github.com/user-attachments/assets/051520f7-8f16-41f9-b5a4-0784a5fe204b" />


## ⚠️ 기타 참고 사항

- 추후 ClothesRepository 구현 완료 시 적용해 소유권 검증 복구

---



Closes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 피드 생성 REST API(POST /api/feeds) 추가: 요청 검증, 성공 시 201 Created와 Location 헤더(/api/feeds/{id}) 및 생성된 피드 반환.
  - 피드 생성 서비스 로직 추가: 작성자/날씨 연동, 의류 항목 중복 제거 및 연관 관계 생성.
- 문서
  - OpenAPI 기반 피드 생성 API 문서화(한글 요약, 보안 요구, 성공/오류 응답 및 Location 헤더 명세).
- 테스트
  - 컨트롤러/서비스 단위 테스트 추가: 정상 흐름, 의류 중복 처리, 작성자/날씨 미존재 오류 검증 등.
- 버그 수정/검증
  - 요청 검증 강화: 내용 길이 제한 추가, 날씨 ID는 선택 항목으로 변경.
- 기타
  - 피드 관련 신규 에러 코드 추가(예: 날씨/피드 관련 NotFound/Forbidden/Gone).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->