### PR TITLE
[Feature] Follow 요약 정보 조회

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/controller/FollowController.java
@@ -2,8 +2,10 @@ package com.onepiece.otboo.domain.follow.controller;
 
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
 import com.onepiece.otboo.domain.follow.service.FollowService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,7 +25,7 @@ public class FollowController {
     @PostMapping
     public ResponseEntity<FollowResponse> createFollow(@RequestBody FollowRequest request) {
         FollowResponse response = followService.createFollow(request);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     /**
@@ -51,5 +53,16 @@ public class FollowController {
     public ResponseEntity<Void> deleteFollow(@RequestBody FollowRequest request) {
         followService.deleteFollow(request);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 팔로우 요약 정보 조회
+     */
+    @GetMapping("/summary/{userId}")
+    public ResponseEntity<FollowSummaryResponse> getFollowSummary(
+        @PathVariable UUID userId,
+        @RequestParam(required = false) UUID viewerId) {
+        FollowSummaryResponse summary = followService.getFollowSummary(userId, viewerId);
+        return ResponseEntity.ok(summary);
     }
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/controller/api/FollowApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/controller/api/FollowApi.java
@@ -2,7 +2,11 @@ package com.onepiece.otboo.domain.follow.controller.api;
 
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,19 +18,66 @@ import java.util.UUID;
 @RequestMapping("/api/follows")
 public interface FollowApi {
 
-    @Operation(summary = "팔로우 생성", description = "사용자가 다른 사용자를 팔로우합니다.")
+    @Operation(
+        summary = "팔로우 생성",
+        description = "사용자가 다른 사용자를 팔로우합니다.",
+        responses = {
+            @ApiResponse(responseCode = "201", description = "팔로우 생성 성공",
+                content = @Content(schema = @Schema(implementation = FollowResponse.class))),
+            @ApiResponse(responseCode = "400", description = "이미 팔로우 관계 존재 또는 잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "대상 사용자 없음")
+        }
+    )
     @PostMapping
     ResponseEntity<FollowResponse> createFollow(@RequestBody FollowRequest request);
 
-    @Operation(summary = "팔로워 목록 조회", description = "특정 사용자를 팔로우하는 모든 사용자 목록을 조회합니다.")
+    @Operation(
+        summary = "팔로워 목록 조회",
+        description = "특정 사용자를 팔로우하는 모든 사용자 목록을 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                content = @Content(schema = @Schema(implementation = FollowResponse.class))),
+            @ApiResponse(responseCode = "404", description = "대상 사용자 없음")
+        }
+    )
     @GetMapping("/followers/{userId}")
     ResponseEntity<List<FollowResponse>> getFollowers(@PathVariable UUID userId);
 
-    @Operation(summary = "팔로잉 목록 조회", description = "특정 사용자가 팔로우하는 사용자 목록을 조회합니다.")
+    @Operation(
+        summary = "팔로잉 목록 조회",
+        description = "특정 사용자가 팔로우하는 사용자 목록을 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                content = @Content(schema = @Schema(implementation = FollowResponse.class))),
+            @ApiResponse(responseCode = "404", description = "대상 사용자 없음")
+        }
+    )
     @GetMapping("/followings/{userId}")
     ResponseEntity<List<FollowResponse>> getFollowings(@PathVariable UUID userId);
 
-    @Operation(summary = "언팔로우", description = "사용자가 특정 사용자를 언팔로우합니다.")
+    @Operation(
+        summary = "언팔로우",
+        description = "사용자가 특정 사용자를 언팔로우합니다.",
+        responses = {
+            @ApiResponse(responseCode = "204", description = "언팔로우 성공"),
+            @ApiResponse(responseCode = "404", description = "대상 사용자 없음")
+        }
+    )
     @DeleteMapping
     ResponseEntity<Void> deleteFollow(@RequestBody FollowRequest request);
+
+    @Operation(
+        summary = "팔로우 요약 조회",
+        description = "특정 사용자의 팔로워 수, 팔로잉 수, viewer 기준 팔로우 여부를 반환합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                content = @Content(schema = @Schema(implementation = FollowSummaryResponse.class))),
+            @ApiResponse(responseCode = "404", description = "대상 사용자 없음")
+        }
+    )
+    @GetMapping("/summary/{userId}")
+    ResponseEntity<FollowSummaryResponse> getFollowSummary(
+        @PathVariable UUID userId,
+        @RequestParam(required = false) UUID viewerId
+    );
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowSummaryResponse.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowSummaryResponse.java
@@ -1,4 +1,23 @@
 package com.onepiece.otboo.domain.follow.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FollowSummaryResponse {
+
+    private UUID userId;
+    private long followerCount;
+    private long followingCount;
+    
+    @JsonProperty("isFollowing")
+    private boolean isFollowing;
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowSummaryResponse.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowSummaryResponse.java
@@ -1,0 +1,4 @@
+package com.onepiece.otboo.domain.follow.dto.response;
+
+public class FollowSummaryResponse {
+}

--- a/src/main/java/com/onepiece/otboo/domain/follow/entity/Follow.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/entity/Follow.java
@@ -1,18 +1,20 @@
 package com.onepiece.otboo.domain.follow.entity;
 
+import com.onepiece.otboo.domain.follow.exception.DuplicateFollowException;
+import com.onepiece.otboo.domain.follow.repository.FollowRepository;
 import com.onepiece.otboo.domain.user.entity.User;
 import com.onepiece.otboo.global.base.BaseEntity;
-import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 @Entity
 @Table(
@@ -34,4 +36,10 @@ public class Follow extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_id", nullable = false)
     private User following;
+
+    public void validateDuplicate(boolean alreadyExists) {
+        if (alreadyExists) {
+            throw DuplicateFollowException.of(this.follower.getId(), this.following.getId());
+        }
+    }
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/exception/DuplicateFollowException.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/exception/DuplicateFollowException.java
@@ -1,0 +1,23 @@
+package com.onepiece.otboo.domain.follow.exception;
+
+import com.onepiece.otboo.global.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class DuplicateFollowException extends FollowException {
+
+    public DuplicateFollowException() {
+        super(ErrorCode.DUPLICATE_FOLLOW);
+    }
+
+    private DuplicateFollowException(Map<String, Object> details) {
+        super(ErrorCode.DUPLICATE_FOLLOW, details);
+    }
+
+    public static DuplicateFollowException of(UUID followerId, UUID followingId) {
+        return new DuplicateFollowException(Map.of(
+            "followerId", followerId,
+            "followingId", followingId
+        ));
+    }
+}

--- a/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepository.java
@@ -16,4 +16,7 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
     void deleteByFollowerAndFollowing(User follower, User following);
 
+    long countByFollowing(User following);
+
+    long countByFollower(User follower);
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/service/FollowService.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/service/FollowService.java
@@ -3,6 +3,7 @@ package com.onepiece.otboo.domain.follow.service;
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
 
+import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,5 +16,7 @@ public interface FollowService {
     List<FollowResponse> getFollowings(UUID userId);
 
     void deleteFollow(FollowRequest request);
+
+    FollowSummaryResponse getFollowSummary(UUID userId, UUID viewerId);
 
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/service/FollowServiceImpl.java
@@ -2,6 +2,7 @@ package com.onepiece.otboo.domain.follow.service;
 
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
 import com.onepiece.otboo.domain.follow.entity.Follow;
 import com.onepiece.otboo.domain.follow.mapper.FollowMapper;
 import com.onepiece.otboo.domain.follow.repository.FollowRepository;
@@ -74,5 +75,28 @@ public class FollowServiceImpl implements FollowService {
             .orElseThrow(() -> new IllegalArgumentException("Following not found"));
 
         followRepository.deleteByFollowerAndFollowing(follower, following);
+    }
+
+    @Override
+    public FollowSummaryResponse getFollowSummary(UUID userId, UUID viewerId) {
+        User targetUser = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        long followerCount = followRepository.countByFollowing(targetUser);
+        long followingCount = followRepository.countByFollower(targetUser);
+
+        boolean isFollowing = false;
+        if (viewerId != null) {
+            User viewer = userRepository.findById(viewerId)
+                .orElseThrow(() -> new IllegalArgumentException("Viewer not found"));
+            isFollowing = followRepository.existsByFollowerAndFollowing(viewer, targetUser);
+        }
+
+        return FollowSummaryResponse.builder()
+            .userId(userId)
+            .followerCount(followerCount)
+            .followingCount(followingCount)
+            .isFollowing(isFollowing)
+            .build();
     }
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/service/FollowServiceImpl.java
@@ -34,14 +34,13 @@ public class FollowServiceImpl implements FollowService {
         User following = userRepository.findById(request.getFollowingId())
             .orElseThrow(() -> UserNotFoundException.byId(request.getFollowingId()));
 
-        if (followRepository.existsByFollowerAndFollowing(follower, following)) {
-            throw DuplicateFollowException.of(request.getFollowerId(), request.getFollowingId());
-        }
-
         Follow follow = Follow.builder()
             .follower(follower)
             .following(following)
             .build();
+
+        boolean alreadyExists = followRepository.existsByFollowerAndFollowing(follower, following);
+        follow.validateDuplicate(alreadyExists);
 
         Follow saved = followRepository.save(follow);
         return followMapper.toResponse(saved);

--- a/src/main/java/com/onepiece/otboo/domain/location/service/LocationServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/location/service/LocationServiceImpl.java
@@ -61,8 +61,8 @@ public class LocationServiceImpl implements LocationService {
         Point point = LatLonToXYConverter.latLonToXY(latitude, longitude);
 
         return Location.builder()
-            .latitude(roundTo4(latitude))
-            .longitude(roundTo4(longitude))
+            .latitude((latitude))
+            .longitude((longitude))
             .locationNames(locationNames)
             .xCoordinate(point.x)
             .yCoordinate(point.y)

--- a/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 확인 실패", "존재하지 않는 사용자입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일", "이미 존재하는 이메일입니다."),
 
+    // FOLLOW
+    DUPLICATE_FOLLOW(HttpStatus.BAD_REQUEST, "팔로우 등록 실패", "이미 해당 사용자를 팔로우하고 있습니다."),
+
     // AUTH
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 올바르지 않습니다.", "아이디 또는 비밀번호를 확인해 주세요."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.", "이 리소스에 접근할 권한이 없습니다."),

--- a/src/test/java/com/onepiece/otboo/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/follow/controller/FollowControllerTest.java
@@ -3,6 +3,7 @@ package com.onepiece.otboo.domain.follow.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
 import com.onepiece.otboo.domain.follow.service.FollowService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,7 +62,7 @@ class FollowControllerTest {
         mockMvc.perform(post("/api/follows")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk())
+            .andExpect(status().isCreated())
             .andExpect(jsonPath("$.followerId").value(followerId.toString()))
             .andExpect(jsonPath("$.followingId").value(followingId.toString()));
     }
@@ -119,4 +120,30 @@ class FollowControllerTest {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isNoContent());
     }
+    @Test
+    @DisplayName("팔로우 요약 조회 성공")
+    void getFollowSummary_success() throws Exception {
+
+        UUID userId = UUID.randomUUID();
+        UUID viewerId = UUID.randomUUID();
+
+        FollowSummaryResponse response = FollowSummaryResponse.builder()
+            .userId(userId)
+            .followerCount(5)
+            .followingCount(3)
+            .isFollowing(true)
+            .build();
+
+        given(followService.getFollowSummary(eq(userId), eq(viewerId))).willReturn(response);
+
+        mockMvc.perform(get("/api/follows/summary/{userId}", userId)
+                .param("viewerId", viewerId.toString())
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.userId").value(userId.toString()))
+            .andExpect(jsonPath("$.followerCount").value(5))
+            .andExpect(jsonPath("$.followingCount").value(3))
+            .andExpect(jsonPath("$.isFollowing").value(true));
+    }
+
 }

--- a/src/test/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryTest.java
@@ -116,4 +116,35 @@ class FollowRepositoryTest {
         boolean exists = followRepository.existsByFollowerAndFollowing(follower, following);
         assertThat(exists).isFalse();
     }
+
+    @Test
+    @DisplayName("특정 사용자의 팔로워 수를 조회할 수 있다")
+    void countByFollowing_success() {
+
+        User following = userRepository.save(createUser("target@test.com"));
+        User follower1 = userRepository.save(createUser("f1@test.com"));
+        User follower2 = userRepository.save(createUser("f2@test.com"));
+        followRepository.save(Follow.builder().follower(follower1).following(following).build());
+        followRepository.save(Follow.builder().follower(follower2).following(following).build());
+
+        long count = followRepository.countByFollowing(following);
+
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("특정 사용자의 팔로잉 수를 조회할 수 있다")
+    void countByFollower_success() {
+
+        User follower = userRepository.save(createUser("f1@test.com"));
+        User following1 = userRepository.save(createUser("f2@test.com"));
+        User following2 = userRepository.save(createUser("f3@test.com"));
+        followRepository.save(Follow.builder().follower(follower).following(following1).build());
+        followRepository.save(Follow.builder().follower(follower).following(following2).build());
+
+        long count = followRepository.countByFollower(follower);
+
+        assertThat(count).isEqualTo(2);
+    }
+
 }

--- a/src/test/java/com/onepiece/otboo/domain/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/follow/service/FollowServiceImplTest.java
@@ -3,11 +3,13 @@ package com.onepiece.otboo.domain.follow.service;
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
 import com.onepiece.otboo.domain.follow.entity.Follow;
+import com.onepiece.otboo.domain.follow.exception.DuplicateFollowException;
 import com.onepiece.otboo.domain.follow.mapper.FollowMapper;
 import com.onepiece.otboo.domain.follow.repository.FollowRepository;
 import com.onepiece.otboo.domain.user.entity.User;
 import com.onepiece.otboo.domain.user.enums.Provider;
 import com.onepiece.otboo.domain.user.enums.Role;
+import com.onepiece.otboo.domain.user.exception.UserNotFoundException;
 import com.onepiece.otboo.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -107,8 +109,7 @@ class FollowServiceImplTest {
         given(followRepository.existsByFollowerAndFollowing(follower, following)).willReturn(true);
 
         assertThatThrownBy(() -> followService.createFollow(request))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Already following");
+            .isInstanceOf(DuplicateFollowException.class);
     }
 
     @Test
@@ -225,8 +226,7 @@ class FollowServiceImplTest {
         given(userRepository.findById(targetUserId)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> followService.getFollowSummary(targetUserId, viewerId))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("User not found");
+            .isInstanceOf(UserNotFoundException.class);
     }
 
 }


### PR DESCRIPTION
## 📌 작업 개요

- 팔로우 정보를 요약하여 제공하는 기능을 구현했습니다.
- 특정 사용자의 팔로워 수, 팔로잉 수, 그리고 조회자가 해당 사용자를 팔로우하고 있는지 여부를 응답으로 내려줍니다.

## ✅ 완료한 작업

- FollowSummaryResponse DTO 추가 및 isFollowing 필드 직렬화 문제 수정
- FollowRepository에 요약 조회 메서드 추가
- FollowService / FollowServiceImpl에 팔로우 요약 로직 구현
- FollowController 및 FollowApi에 팔로우 요약 API 엔드포인트 추가
- 컨트롤러/서비스/레포지토리 단위 테스트 작성 및 검증

## 🧪 테스트 결과


- 로컬 테스트 완료


## ⚠️ 기타 참고 사항

<img width="1451" height="825" alt="스크린샷 2025-09-18 오후 1 15 39" src="https://github.com/user-attachments/assets/3e46b8e3-7b4c-4a39-8a11-a30deae7711c" />

저번 PR에서 리뷰해주셨는데 수정하지 못 했던 사항을 일부 반영했습니다!

---

Related Issue #39

Closes #39


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 팔로우 요약 조회 API 추가: GET /summary/{userId} (viewerId 옵션). 팔로워/팔로잉 수와 팔로잉 여부 제공.
  - 팔로우 요약 응답 DTO(FollowSummaryResponse) 및 카운트 조회 저장소 메서드 추가.
- Bug Fixes
  - 팔로우 생성 성공 시 HTTP 201 Created로 응답 상태 코드 수정.
  - 중복 팔로우에 대한 명확한 예외(DuplicateFollowException)와 오류 코드 추가; 존재하지 않는 사용자에 대해 404 일관화.
- Documentation
  - OpenAPI 문서 확장: 각 엔드포인트의 응답 코드 및 페이로드 상세 명시.
- Tests
  - 요약 조회 및 카운트/중복 관련 단위/통합 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->