### PR TITLE
[Fix] 위치 정보 조회 시 무한 요청이 가던 오류 수정

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/location/service/LocationServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/location/service/LocationServiceImpl.java
@@ -61,15 +61,11 @@ public class LocationServiceImpl implements LocationService {
         Point point = LatLonToXYConverter.latLonToXY(latitude, longitude);
 
         return Location.builder()
-            .latitude(roundTo4(latitude))
-            .longitude(roundTo4(longitude))
+            .latitude(latitude)
+            .longitude(longitude)
             .locationNames(locationNames)
             .xCoordinate(point.x)
             .yCoordinate(point.y)
             .build();
-    }
-
-    private double roundTo4(double value) {
-        return Math.round(value * 10000d) / 10000d;
     }
 }

--- a/src/test/java/com/onepiece/otboo/domain/location/service/LocationServiceImplTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/location/service/LocationServiceImplTest.java
@@ -70,27 +70,4 @@ class LocationServiceImplTest {
         verify(locationProvider).getLocation(longitude, latitude);
         verify(persistenceService).save(any(Location.class));
     }
-
-    @Test
-    void 위도_경도_반올림_적용_테스트() {
-        // given
-        ArgumentCaptor<Location> captor = ArgumentCaptor.forClass(Location.class);
-
-        given(locationProvider.getLocation(longitude, latitude)).willReturn(item);
-        given(persistenceService.save(any(Location.class)))
-            .willAnswer(invocation -> invocation.getArgument(0)); // save 대상 그대로 반환
-
-        // when
-        WeatherAPILocation result = locationService.getLocation(longitude, latitude);
-
-        // then
-        verify(persistenceService).save(captor.capture());
-        Location saved = captor.getValue();
-        assertEquals(37.4375, saved.getLatitude());
-        assertEquals(126.8055, saved.getLongitude());
-        assertEquals("경기도,시흥시,은행동,", saved.getLocationNames());
-        assertEquals(37.4375, result.latitude());
-        assertEquals(126.8055, result.longitude());
-        assertThat(result.locationNames()).contains("경기도", "시흥시", "은행동");
-    }
 }


### PR DESCRIPTION
## 📌 작업 개요

- 위치 정보 조회 시 무한 요청이 가던 오류 수정

## ✅ 완료한 작업

- 기존에 위/경도 값을 소수점 4자리까지 반올림 후 저장 하던 로직 제거

## 🧪 테스트 결과

- 로컬 테스트 완료

## ⚠️ 기타 참고 사항

- 아까 보여드린 대로 요청이 한번만 갑니다. 😄
- 아무나 2분이 승인 해주시면 될 것 같습니다
---

## Related Issue

Closes #56 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 위치 좌표 처리 로직을 개선해 반올림을 제거하고 원본 위도·경도를 사용합니다. 이로써 위치 표시, 거리 계산, 주변 추천 등 위치 기반 기능의 정확도가 향상되고 경계 지점의 오차/오매칭 가능성이 감소합니다. 공개 API 사용 방식은 동일합니다.
- Tests
  - 변경된 좌표 처리에 맞춰 반올림 검증 테스트를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->