### PR TITLE
[Feature] Location 중복 저장 방지 기능 추가

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/location/repository/LocationRepository.java
+++ b/src/main/java/com/onepiece/otboo/domain/location/repository/LocationRepository.java
@@ -1,9 +1,10 @@
 package com.onepiece.otboo.domain.location.repository;
 
 import com.onepiece.otboo.domain.location.entity.Location;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LocationRepository extends JpaRepository<Location, UUID> {
-
+    Optional<Location> findByLatitudeAndLongitude(double latitude, double longitude);
 }

--- a/src/main/java/com/onepiece/otboo/domain/location/service/LocationPersistenceService.java
+++ b/src/main/java/com/onepiece/otboo/domain/location/service/LocationPersistenceService.java
@@ -2,6 +2,7 @@ package com.onepiece.otboo.domain.location.service;
 
 import com.onepiece.otboo.domain.location.entity.Location;
 import com.onepiece.otboo.domain.location.repository.LocationRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,5 +16,10 @@ public class LocationPersistenceService {
     @Transactional
     public Location save(Location location) {
         return locationRepository.save(location);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Location> findByLatitudeAndLongitude(double latitude, double longitude) {
+        return locationRepository.findByLatitudeAndLongitude(latitude, longitude);
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -38,228 +38,248 @@
 /**
 ============= 사용자, 위치 정보 =============
  */
-CREATE TABLE IF NOT EXISTS users (
-  id              uuid PRIMARY KEY,
-  provider        varchar(20) NOT NULL DEFAULT 'LOCAL',
-  provider_user_id varchar(255),
-  email           varchar(255) NOT NULL UNIQUE,
-  password        varchar(255) NOT NULL,
-  temporary_password varchar(255),
-  temporary_password_expiration_time TIMESTAMP WITH TIME ZONE,
-  role            varchar(20) NOT NULL DEFAULT 'USER',
-  locked          boolean NOT NULL DEFAULT false,
-  created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at      TIMESTAMP WITH TIME ZONE,
-  CHECK (provider IN ('LOCAL','GOOGLE','KAKAO')),
-  CHECK (role IN ('USER','ADMIN')),
-  UNIQUE (provider, provider_user_id)
+CREATE TABLE IF NOT EXISTS users
+(
+    id                                 uuid PRIMARY KEY,
+    provider                           varchar(20)              NOT NULL DEFAULT 'LOCAL',
+    provider_user_id                   varchar(255),
+    email                              varchar(255)             NOT NULL UNIQUE,
+    password                           varchar(255)             NOT NULL,
+    temporary_password                 varchar(255),
+    temporary_password_expiration_time TIMESTAMP WITH TIME ZONE,
+    role                               varchar(20)              NOT NULL DEFAULT 'USER',
+    locked                             boolean                  NOT NULL DEFAULT false,
+    created_at                         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at                         TIMESTAMP WITH TIME ZONE,
+    CHECK (provider IN ('LOCAL', 'GOOGLE', 'KAKAO')),
+    CHECK (role IN ('USER', 'ADMIN')),
+    UNIQUE (provider, provider_user_id)
 );
 
-CREATE TABLE IF NOT EXISTS locations (
-  id             uuid PRIMARY KEY,
-  latitude       double precision NOT NULL,
-  longitude      double precision NOT NULL,
-  x_coordinate   integer NOT NULL,
-  y_coordinate   integer NOT NULL,
-  location_names varchar(255) NOT NULL,
-  CHECK (latitude  BETWEEN -90  AND 90),
-  CHECK (longitude BETWEEN -180 AND 180)
+CREATE TABLE IF NOT EXISTS locations
+(
+    id             uuid PRIMARY KEY,
+    latitude       double precision NOT NULL,
+    longitude      double precision NOT NULL,
+    x_coordinate   integer          NOT NULL,
+    y_coordinate   integer          NOT NULL,
+    location_names varchar(255)     NOT NULL,
+    CHECK (latitude BETWEEN -90 AND 90),
+    CHECK (longitude BETWEEN -180 AND 180),
+    UNIQUE (latitude, longitude)
 );
 
-CREATE TABLE IF NOT EXISTS user_profiles (
-  id                 uuid PRIMARY KEY,
-  user_id            uuid NOT NULL,
-  location_id        uuid,
-  nickname           varchar(100) NOT NULL,
-  profile_image_url  varchar(255),
-  gender             varchar(20),
-  birth_date         date,
-  temp_sensitivity   integer,
-  created_at         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at         TIMESTAMP WITH TIME ZONE,
-  UNIQUE (user_id),
-  CHECK (gender IN ('MALE','FEMALE','OTHER')),
-  CHECK (temp_sensitivity BETWEEN 1 AND 5),
-  FOREIGN KEY (user_id)    REFERENCES users(id)     ON DELETE CASCADE,
-  FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE SET NULL
+CREATE TABLE IF NOT EXISTS user_profiles
+(
+    id                uuid PRIMARY KEY,
+    user_id           uuid                     NOT NULL,
+    location_id       uuid,
+    nickname          varchar(100)             NOT NULL,
+    profile_image_url varchar(255),
+    gender            varchar(20),
+    birth_date        date,
+    temp_sensitivity  integer,
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMP WITH TIME ZONE,
+    UNIQUE (user_id),
+    CHECK (gender IN ('MALE', 'FEMALE', 'OTHER')),
+    CHECK (temp_sensitivity BETWEEN 1 AND 5),
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    FOREIGN KEY (location_id) REFERENCES locations (id) ON DELETE SET NULL
 );
 
 /**
 ============= 옷장 =============
  */
-CREATE TABLE IF NOT EXISTS clothes (
-  id         uuid PRIMARY KEY,
-  owner_id   uuid NOT NULL,
-  name       varchar(255),
-  type       varchar(20),
-  image_url  text,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE,
-  FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE,
-  CHECK (type IN ('TOP','BOTTOM','DRESS','OUTER','UNDERWEAR','ACCESSORY','SHOES','SOCKS','HAT','BAG','SCARF','ETC'))
+CREATE TABLE IF NOT EXISTS clothes
+(
+    id         uuid PRIMARY KEY,
+    owner_id   uuid                     NOT NULL,
+    name       varchar(255),
+    type       varchar(20),
+    image_url  text,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE,
+    FOREIGN KEY (owner_id) REFERENCES users (id) ON DELETE CASCADE,
+    CHECK (type IN
+           ('TOP', 'BOTTOM', 'DRESS', 'OUTER', 'UNDERWEAR', 'ACCESSORY', 'SHOES', 'SOCKS', 'HAT',
+            'BAG', 'SCARF', 'ETC'))
 );
 
-CREATE TABLE IF NOT EXISTS clothes_attribute_defs (
-  id         uuid PRIMARY KEY,
-  name       varchar(100) NOT NULL,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE,
-  UNIQUE (name)
+CREATE TABLE IF NOT EXISTS clothes_attribute_defs
+(
+    id         uuid PRIMARY KEY,
+    name       varchar(100)             NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP WITH TIME ZONE,
+    UNIQUE (name)
 );
 
-CREATE TABLE IF NOT EXISTS clothes_attribute_options (
-  id            uuid PRIMARY KEY,
-  option_value  varchar(50) NOT NULL,
-  definition_id uuid NOT NULL,
-  FOREIGN KEY (definition_id) REFERENCES clothes_attribute_defs(id) ON DELETE CASCADE,
-  UNIQUE (definition_id, option_value)
+CREATE TABLE IF NOT EXISTS clothes_attribute_options
+(
+    id            uuid PRIMARY KEY,
+    option_value  varchar(50) NOT NULL,
+    definition_id uuid        NOT NULL,
+    FOREIGN KEY (definition_id) REFERENCES clothes_attribute_defs (id) ON DELETE CASCADE,
+    UNIQUE (definition_id, option_value)
 );
 
-CREATE TABLE IF NOT EXISTS clothes_attributes (
-  id            uuid PRIMARY KEY,
-  clothes_id    uuid NOT NULL,
-  definition_id uuid NOT NULL,
-  option_id     uuid NOT NULL,
-  created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at    TIMESTAMP WITH TIME ZONE,
-  FOREIGN KEY (clothes_id)    REFERENCES clothes(id)                ON DELETE CASCADE,
-  FOREIGN KEY (definition_id) REFERENCES clothes_attribute_defs(id) ON DELETE CASCADE,
-  FOREIGN KEY (option_id)     REFERENCES clothes_attribute_options(id) ON DELETE CASCADE,
-  UNIQUE (clothes_id, definition_id)
+CREATE TABLE IF NOT EXISTS clothes_attributes
+(
+    id            uuid PRIMARY KEY,
+    clothes_id    uuid                     NOT NULL,
+    definition_id uuid                     NOT NULL,
+    option_id     uuid                     NOT NULL,
+    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMP WITH TIME ZONE,
+    FOREIGN KEY (clothes_id) REFERENCES clothes (id) ON DELETE CASCADE,
+    FOREIGN KEY (definition_id) REFERENCES clothes_attribute_defs (id) ON DELETE CASCADE,
+    FOREIGN KEY (option_id) REFERENCES clothes_attribute_options (id) ON DELETE CASCADE,
+    UNIQUE (clothes_id, definition_id)
 );
 
 /**
 ============= 날씨 데이터 =============
  */
-CREATE TABLE IF NOT EXISTS weather_data (
-  id                                   uuid PRIMARY KEY,
-  location_id                           uuid NOT NULL,
-  forecasted_at                         TIMESTAMP WITH TIME ZONE,
-  forecast_at                           TIMESTAMP WITH TIME ZONE,
-  temperature_current                   double precision NOT NULL,
-  temperature_max                       double precision,
-  temperature_min                       double precision,
-  temperature_compared_to_day_before    double precision,
-  sky_status                            varchar(16),
-  precipitation_amount                  double precision,
-  precipitation_probability             double precision,
-  precipitation_type                    varchar(16),
-  wind_speed                            double precision,
-  wind_speed_as_word                    varchar(16),
-  humidity                              double precision,
-  humidity_compared_to_day_before       double precision,
-  created_at                            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE CASCADE,
-  CHECK (sky_status IN ('CLEAR','MOSTLY_CLOUDY','CLOUDY')),
-  CHECK (precipitation_type IN ('NONE','RAIN','RAIN_SNOW','SNOW','SHOWER')),
-  CHECK (wind_speed_as_word IN ('WEAK','MODERATE','STRONG'))
+CREATE TABLE IF NOT EXISTS weather_data
+(
+    id                                 uuid PRIMARY KEY,
+    location_id                        uuid                     NOT NULL,
+    forecasted_at                      TIMESTAMP WITH TIME ZONE,
+    forecast_at                        TIMESTAMP WITH TIME ZONE,
+    temperature_current                double precision         NOT NULL,
+    temperature_max                    double precision,
+    temperature_min                    double precision,
+    temperature_compared_to_day_before double precision,
+    sky_status                         varchar(16),
+    precipitation_amount               double precision,
+    precipitation_probability          double precision,
+    precipitation_type                 varchar(16),
+    wind_speed                         double precision,
+    wind_speed_as_word                 varchar(16),
+    humidity                           double precision,
+    humidity_compared_to_day_before    double precision,
+    created_at                         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    FOREIGN KEY (location_id) REFERENCES locations (id) ON DELETE CASCADE,
+    CHECK (sky_status IN ('CLEAR', 'MOSTLY_CLOUDY', 'CLOUDY')),
+    CHECK (precipitation_type IN ('NONE', 'RAIN', 'RAIN_SNOW', 'SNOW', 'SHOWER')),
+    CHECK (wind_speed_as_word IN ('WEAK', 'MODERATE', 'STRONG'))
 );
 
 /*
 ============= FEED & SOCIAL (피드/댓글/좋아요/팔로우/DM) =============
  */
-CREATE TABLE IF NOT EXISTS feeds (
-  id            uuid PRIMARY KEY,
-  author_id     uuid NOT NULL,
-  weather_id    uuid,
-  content       varchar(1000),
-  comment_count bigint  NOT NULL DEFAULT 0,
-  like_count    bigint  NOT NULL DEFAULT 0,
-  created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at    TIMESTAMP WITH TIME ZONE,
-  FOREIGN KEY (author_id)  REFERENCES users(id)        ON DELETE CASCADE,
-  FOREIGN KEY (weather_id) REFERENCES weather_data(id) ON DELETE SET NULL
+CREATE TABLE IF NOT EXISTS feeds
+(
+    id            uuid PRIMARY KEY,
+    author_id     uuid                     NOT NULL,
+    weather_id    uuid,
+    content       varchar(1000),
+    comment_count bigint                   NOT NULL DEFAULT 0,
+    like_count    bigint                   NOT NULL DEFAULT 0,
+    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMP WITH TIME ZONE,
+    FOREIGN KEY (author_id) REFERENCES users (id) ON DELETE CASCADE,
+    FOREIGN KEY (weather_id) REFERENCES weather_data (id) ON DELETE SET NULL
 );
 
-CREATE TABLE IF NOT EXISTS feed_comments (
-  id         uuid PRIMARY KEY,
-  author_id  uuid NOT NULL,
-  feed_id    uuid NOT NULL,
-  content    varchar(200) NOT NULL,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE,
-  FOREIGN KEY (feed_id)   REFERENCES feeds(id) ON DELETE CASCADE
+CREATE TABLE IF NOT EXISTS feed_comments
+(
+    id         uuid PRIMARY KEY,
+    author_id  uuid                     NOT NULL,
+    feed_id    uuid                     NOT NULL,
+    content    varchar(200)             NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    FOREIGN KEY (author_id) REFERENCES users (id) ON DELETE CASCADE,
+    FOREIGN KEY (feed_id) REFERENCES feeds (id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS feed_likes (
-  id         uuid PRIMARY KEY,
-  user_id    uuid NOT NULL,
-  feed_id    uuid NOT NULL,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  UNIQUE (user_id, feed_id),
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-  FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE
+CREATE TABLE IF NOT EXISTS feed_likes
+(
+    id         uuid PRIMARY KEY,
+    user_id    uuid                     NOT NULL,
+    feed_id    uuid                     NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    UNIQUE (user_id, feed_id),
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    FOREIGN KEY (feed_id) REFERENCES feeds (id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS feed_clothes (
-  id         uuid PRIMARY KEY,
-  feed_id    uuid NOT NULL,
-  clothes_id uuid NOT NULL,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  UNIQUE (feed_id, clothes_id),
-  FOREIGN KEY (feed_id)    REFERENCES feeds(id)   ON DELETE CASCADE,
-  FOREIGN KEY (clothes_id) REFERENCES clothes(id) ON DELETE CASCADE
+CREATE TABLE IF NOT EXISTS feed_clothes
+(
+    id         uuid PRIMARY KEY,
+    feed_id    uuid                     NOT NULL,
+    clothes_id uuid                     NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    UNIQUE (feed_id, clothes_id),
+    FOREIGN KEY (feed_id) REFERENCES feeds (id) ON DELETE CASCADE,
+    FOREIGN KEY (clothes_id) REFERENCES clothes (id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS follows (
-  id           uuid PRIMARY KEY,
-  created_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  follower_id  uuid NOT NULL,
-  following_id uuid NOT NULL,
-  UNIQUE (follower_id, following_id),
-  CHECK (follower_id <> following_id),
-  FOREIGN KEY (follower_id)  REFERENCES users(id) ON DELETE CASCADE,
-  FOREIGN KEY (following_id) REFERENCES users(id) ON DELETE CASCADE
+CREATE TABLE IF NOT EXISTS follows
+(
+    id           uuid PRIMARY KEY,
+    created_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    follower_id  uuid                     NOT NULL,
+    following_id uuid                     NOT NULL,
+    UNIQUE (follower_id, following_id),
+    CHECK (follower_id <> following_id),
+    FOREIGN KEY (follower_id) REFERENCES users (id) ON DELETE CASCADE,
+    FOREIGN KEY (following_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS direct_messages (
-  id          uuid PRIMARY KEY,
-  content     text NOT NULL,
-  created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  receiver_id uuid NOT NULL,
-  sender_id   uuid NOT NULL,
-  FOREIGN KEY (receiver_id) REFERENCES users(id) ON DELETE CASCADE,
-  FOREIGN KEY (sender_id)   REFERENCES users(id) ON DELETE CASCADE
+CREATE TABLE IF NOT EXISTS direct_messages
+(
+    id          uuid PRIMARY KEY,
+    content     text                     NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    receiver_id uuid                     NOT NULL,
+    sender_id   uuid                     NOT NULL,
+    FOREIGN KEY (receiver_id) REFERENCES users (id) ON DELETE CASCADE,
+    FOREIGN KEY (sender_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
 /*
 ============= RECOMMENDATION & NOTI (추천/알림) =============
  */
-CREATE TABLE IF NOT EXISTS recommendation (
-  id          uuid PRIMARY KEY,
-  user_id     uuid NOT NULL,
-  weather_id  uuid NOT NULL,
-  created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  FOREIGN KEY (user_id)    REFERENCES users(id)        ON DELETE CASCADE,
-  FOREIGN KEY (weather_id) REFERENCES weather_data(id) ON DELETE CASCADE,
-  UNIQUE (user_id, weather_id)
+CREATE TABLE IF NOT EXISTS recommendation
+(
+    id         uuid PRIMARY KEY,
+    user_id    uuid                     NOT NULL,
+    weather_id uuid                     NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    FOREIGN KEY (weather_id) REFERENCES weather_data (id) ON DELETE CASCADE,
+    UNIQUE (user_id, weather_id)
 );
 
-CREATE TABLE IF NOT EXISTS recommendation_clothes (
-  id                  uuid PRIMARY KEY,
-  clothes_id          uuid NOT NULL,
-  recommendation_id   uuid NOT NULL,
-  UNIQUE (recommendation_id, clothes_id),
-  FOREIGN KEY (clothes_id)        REFERENCES clothes(id)         ON DELETE CASCADE,
-  FOREIGN KEY (recommendation_id) REFERENCES recommendation(id) ON DELETE CASCADE
+CREATE TABLE IF NOT EXISTS recommendation_clothes
+(
+    id                uuid PRIMARY KEY,
+    clothes_id        uuid NOT NULL,
+    recommendation_id uuid NOT NULL,
+    UNIQUE (recommendation_id, clothes_id),
+    FOREIGN KEY (clothes_id) REFERENCES clothes (id) ON DELETE CASCADE,
+    FOREIGN KEY (recommendation_id) REFERENCES recommendation (id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS notifications (
-  id          uuid PRIMARY KEY,
-  level       varchar(20) NOT NULL,
-  title       varchar(255) NOT NULL,
-  content     varchar(255) NOT NULL,
-  created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  receiver_id uuid NOT NULL,
-  FOREIGN KEY (receiver_id) REFERENCES users(id) ON DELETE CASCADE,
-  CHECK (level IN ('INFO','WARNING','ERROR'))
+CREATE TABLE IF NOT EXISTS notifications
+(
+    id          uuid PRIMARY KEY,
+    level       varchar(20)              NOT NULL,
+    title       varchar(255)             NOT NULL,
+    content     varchar(255)             NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    receiver_id uuid                     NOT NULL,
+    FOREIGN KEY (receiver_id) REFERENCES users (id) ON DELETE CASCADE,
+    CHECK (level IN ('INFO', 'WARNING', 'ERROR'))
 );
 
 /*
 ============= INDEX (조회 성능 최적화용) =============
  */
 CREATE INDEX IF NOT EXISTS idx_dm_receiver_created_at ON direct_messages (receiver_id, created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_dm_sender_created_at   ON direct_messages (sender_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_dm_sender_created_at ON direct_messages (sender_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_feed_comments_feed_created_at ON feed_comments (feed_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_feed_likes_feed ON feed_likes (feed_id);
 CREATE INDEX IF NOT EXISTS idx_feed_author_created_at ON feeds (author_id, created_at DESC);

--- a/src/test/java/com/onepiece/otboo/domain/location/fixture/LocationFixture.java
+++ b/src/test/java/com/onepiece/otboo/domain/location/fixture/LocationFixture.java
@@ -34,7 +34,7 @@ public class LocationFixture {
     }
 
     private static String randomLocationNames() {
-        String[] names = {"서울특별시 중구", "부산광역시 해운대구", "대구광역시 수성구", "광주광역시 동구", "제주시"};
+        String[] names = {"서울특별시,중구", "부산광역시,해운대구", "대구광역시,수성구", "광주광역시,동구", "제주시"};
         return names[random.nextInt(names.length)];
     }
 }

--- a/src/test/java/com/onepiece/otboo/domain/location/service/LocationPersistenceServiceTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/location/service/LocationPersistenceServiceTest.java
@@ -1,13 +1,16 @@
 package com.onepiece.otboo.domain.location.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.BDDMockito.given;
 
 import com.onepiece.otboo.domain.location.entity.Location;
 import com.onepiece.otboo.domain.location.fixture.LocationFixture;
 import com.onepiece.otboo.domain.location.repository.LocationRepository;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +29,7 @@ class LocationPersistenceServiceTest {
     LocationPersistenceService persistenceService;
 
     @Test
-    void 지역_저장_테스트() {
+    void Location_저장_테스트() {
 
         // given
         Location location = LocationFixture.createLocation();
@@ -41,5 +44,25 @@ class LocationPersistenceServiceTest {
         // then
         assertNotNull(saved);
         assertEquals(id, saved.getId());
+    }
+
+    @Test
+    void 위도_경도로_Loation_조회_테스트() {
+
+        // given
+        Location location = LocationFixture.createLocation();
+        UUID id = UUID.randomUUID();
+        ReflectionTestUtils.setField(location, "id", id);
+
+        given(locationRepository.findByLatitudeAndLongitude(anyDouble(), anyDouble()))
+            .willReturn(Optional.of(location));
+
+        // when
+        Optional<Location> result = persistenceService.findByLatitudeAndLongitude(location.getLatitude(),
+            location.getLongitude());
+
+        // then
+        assertThat(result).isPresent();
+        assertEquals(location.getLocationNames(), result.get().getLocationNames());
     }
 }

--- a/src/test/java/com/onepiece/otboo/domain/location/service/LocationServiceImplTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/location/service/LocationServiceImplTest.java
@@ -70,4 +70,25 @@ class LocationServiceImplTest {
         verify(locationProvider).getLocation(longitude, latitude);
         verify(persistenceService).save(any(Location.class));
     }
+
+    @Test
+    void 위도_경도_반올림_적용_테스트() {
+        // given
+        ArgumentCaptor<Location> captor = ArgumentCaptor.forClass(Location.class);
+
+        given(locationProvider.getLocation(longitude, latitude)).willReturn(item);
+        given(persistenceService.save(any(Location.class)))
+            .willAnswer(invocation -> invocation.getArgument(0)); // save 대상 그대로 반환
+
+        // when
+        WeatherAPILocation result = locationService.getLocation(longitude, latitude);
+
+        // then
+        verify(persistenceService).save(captor.capture());
+        Location saved = captor.getValue();
+        assertEquals(37.4375, saved.getLatitude());
+        assertEquals(126.8055, saved.getLongitude());
+        assertEquals("경기도,시흥시,은행동,", saved.getLocationNames());
+        assertThat(result.locationNames()).contains("경기도", "시흥시", "은행동");
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요

- Location 중복 저장 방지 기능 추가

## ✅ 완료한 작업

- [x] `schema.sql`에 (latitude, longitude) 유니크 제약 조건 추가
- [x] 지역 정보 조회 시 DB에 없는 경우에만 카카오 API 호출  
- [x] `LocationFixture` 변경 
- [x] 위/경도로 Location 조회 테스트 추가
 
## 🧪 테스트 결과

<img width="926" height="294" alt="image" src="https://github.com/user-attachments/assets/8a2e79b8-27ec-4947-9f62-c9817e82502c" />

## ⚠️ 기타 참고 사항

- DB에는 소수점 4자리까지 저장하고 응답은 요청 보낸 위/경도 값을 그대로 반환해서 어제처럼 무한 요청이 날아가지 않습니다 :) 
- Entity 클래스에는 따로 unique 제약을 추가하진 않았습니다.
---

## Related Issue

Closes #58 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 위도·경도 값으로 위치를 직접 조회해 결과를 제공합니다.

* 리팩터링
  * 입력 좌표를 소수점 4자리로 반올림해 일관된 위치 저장/표시를 보장합니다.
  * 동일 좌표 재조회 시 저장된 위치를 재사용해 응답 체감 속도를 개선했습니다.
  * 위치 좌표의 고유성 보장 및 날씨 데이터 조회 인덱스 추가로 예보 조회 성능과 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->