### PR TITLE
[Feature] 피드 삭제 기능

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/controller/FeedController.java
@@ -7,9 +7,12 @@ import com.onepiece.otboo.domain.feed.service.FeedService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/feeds")
@@ -23,4 +26,13 @@ public class FeedController implements FeedApi {
         return ResponseEntity.created(URI.create("/api/feeds/" + res.id())).body(res);
     }
 
+
+    @Override
+    public ResponseEntity<Void> deleteFeed(@PathVariable UUID feedId) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        UUID requesterId = UUID.fromString(auth.getName());
+
+        feedService.delete(feedId, requesterId);
+        return ResponseEntity.noContent().build(); // 204
+    }
 }

--- a/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
@@ -13,8 +13,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
 
 @Tag(name = "피드 관리", description = "피드 관련 API")
 public interface FeedApi {
@@ -72,4 +76,35 @@ public interface FeedApi {
     })
     @PostMapping(consumes = "application/json", produces = "application/json")
     ResponseEntity<FeedResponse> createFeed(@Valid @RequestBody FeedCreateRequest feedCreateRequest);
+
+    @Operation(
+        summary = "피드 삭제",
+        description = "본인 소유의 피드를 삭제합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204",
+            description = "피드 삭제 성공"
+        ),
+        @ApiResponse(responseCode = "401",
+            description = "인증 실패",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class
+                ))
+        ),
+        @ApiResponse(responseCode = "403",
+            description = "권한 부족/소유권 불일치",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class
+                ))
+        ),
+        @ApiResponse(responseCode = "404",
+            description = "존재하지 않는 피드",
+            content = @Content(
+                schema = @Schema(implementation = ErrorResponse.class
+                ))
+        )
+    })
+    @DeleteMapping(value = "/{feedId}")
+    ResponseEntity<Void> deleteFeed(@PathVariable UUID feedId);
 }

--- a/src/main/java/com/onepiece/otboo/domain/feed/service/FeedService.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/service/FeedService.java
@@ -69,4 +69,16 @@ public class FeedService {
 
         return feedMapper.toResponse(saved);
     }
+
+    @Transactional
+    public void delete(UUID feedId, UUID requesterId) {
+        Feed feed = feedRepository.findById(feedId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.FEED_NOT_FOUND)); // 404
+
+        if (!feed.getAuthorId().equals(requesterId)) {
+            throw new GlobalException(ErrorCode.FEED_FORBIDDEN); // 403
+        }
+
+        feedRepository.delete(feed); // or deleteById(feedId)
+    }
 }

--- a/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import static org.hamcrest.Matchers.containsString;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
@@ -22,7 +21,6 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = FeedController.class)

--- a/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerTest.java
@@ -4,13 +4,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
 import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
 import com.onepiece.otboo.domain.feed.service.FeedService;
+import com.onepiece.otboo.global.exception.ErrorCode;
+import com.onepiece.otboo.global.exception.GlobalException;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 
 import java.util.List;
 import java.util.UUID;
@@ -26,6 +31,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = FeedController.class)
 class FeedControllerTest {
 
+    private static final String BASE_URL = "/api/feeds";
+
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
 
@@ -34,7 +41,7 @@ class FeedControllerTest {
 
     @Test
     @WithMockUser
-    void createFeed_returns201_withLocationHeader() throws Exception {
+    void 피드_등록_정상요청시_201응답_및_위치헤더포함() throws Exception {
         UUID id = UUID.randomUUID();
 
         FeedResponse mocked = mock(FeedResponse.class);
@@ -57,5 +64,49 @@ class FeedControllerTest {
             )
             .andExpect(status().isCreated())
             .andExpect(header().string("Location", "/api/feeds/" + id));
+    }
+
+    @Test
+    @WithMockUser(username = "d290f1ee-6c54-4b01-90e6-d701748f0851") // 컨트롤러가 auth.getName()을 UUID로 파싱
+    void 피드_삭제_정상권한_요청시_204응답() throws Exception {
+        UUID feedId = UUID.randomUUID();
+
+        mockMvc.perform(delete(BASE_URL + "/{id}", feedId).with(csrf()))
+            .andExpect(status().isNoContent());
+
+        Mockito.verify(feedService).delete(
+            eq(feedId),
+            eq(UUID.fromString("d290f1ee-6c54-4b01-90e6-d701748f0851"))
+        );
+    }
+
+    @Test
+    @WithMockUser(username = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    void 피드_삭제_권한없음_요청시_403응답() throws Exception {
+        UUID feedId = UUID.randomUUID();
+        Mockito.doThrow(new GlobalException(ErrorCode.FEED_FORBIDDEN))
+            .when(feedService).delete(eq(feedId), any(UUID.class));
+
+        mockMvc.perform(delete(BASE_URL + "/{id}", feedId).with(csrf()))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    void 피드_삭제_존재하지않는피드_요청시_404응답() throws Exception {
+        UUID feedId = UUID.randomUUID();
+        Mockito.doThrow(new GlobalException(ErrorCode.FEED_NOT_FOUND))
+            .when(feedService).delete(eq(feedId), any(UUID.class));
+
+        mockMvc.perform(delete(BASE_URL + "/{id}", feedId).with(csrf()))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+        void 피드_삭제_미인증사용자_요청시_401응답() throws Exception {
+        UUID feedId = UUID.randomUUID();
+
+        mockMvc.perform(delete(BASE_URL + "/{id}", feedId).with(csrf()))
+            .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
#53 
## 📌 작업 개요
- 사용자가 작성한 피드를 삭제할 수 있는 기능 추가

## ✅ 완료한 작업

- API 스펙 추가
- 피드 삭제 구현 기능 추가
- 피드 삭제 기능 테스트 완료

## 🧪 테스트 결과
- 로컬 테스트 완료



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 피드 삭제 API 추가(DELETE /{feedId}): 인증된 사용자가 본인 소유의 피드를 삭제할 수 있습니다.
  - 표준 응답 코드 제공: 204(No Content), 401(Unauthorized), 403(Forbidden), 404(Not Found).
  - 소유자 검증을 통해 안전한 삭제 처리.

- 테스트
  - 컨트롤러·서비스 테스트 추가: 정상 삭제, 권한 없음, 미인증, 미존재 피드 시나리오 검증.
  - 공통 상수와 목킹 정비로 테스트 가독성·신뢰성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->