### PR TITLE
[Feature] Following 목록 조회

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/controller/FollowController.java
@@ -3,6 +3,7 @@ package com.onepiece.otboo.domain.follow.controller;
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
 import com.onepiece.otboo.domain.follow.service.FollowService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -38,11 +39,11 @@ public class FollowController {
     }
 
     /**
-     * 팔로잉 목록 조회
+     * 팔로잉 목록 조회 (프로필 포함)
      */
     @GetMapping("/followings/{userId}")
-    public ResponseEntity<List<FollowResponse>> getFollowings(@PathVariable UUID userId) {
-        List<FollowResponse> responses = followService.getFollowings(userId);
+    public ResponseEntity<List<FollowingResponse>> getFollowings(@PathVariable UUID userId) {
+        List<FollowingResponse> responses = followService.getFollowings(userId);
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/com/onepiece/otboo/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/controller/FollowController.java
@@ -1,68 +1,69 @@
 package com.onepiece.otboo.domain.follow.controller;
 
+import com.onepiece.otboo.domain.follow.controller.api.FollowApi;
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
+import com.onepiece.otboo.global.dto.response.CursorPageResponseDto;
 import com.onepiece.otboo.domain.follow.service.FollowService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/follows")
 @RequiredArgsConstructor
-public class FollowController {
+public class FollowController implements FollowApi {
 
     private final FollowService followService;
 
-    /**
-     * 팔로우 생성
-     */
-    @PostMapping
-    public ResponseEntity<FollowResponse> createFollow(@RequestBody FollowRequest request) {
+    @Override
+    public ResponseEntity<FollowResponse> createFollow(FollowRequest request) {
         FollowResponse response = followService.createFollow(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    /**
-     * 팔로워 목록 조회
-     */
-    @GetMapping("/followers/{userId}")
-    public ResponseEntity<List<FollowResponse>> getFollowers(@PathVariable UUID userId) {
-        List<FollowResponse> responses = followService.getFollowers(userId);
+    @Override
+    public ResponseEntity<CursorPageResponseDto<FollowResponse>> getFollowers(
+        UUID followeeId,
+        String cursor,
+        UUID idAfter,
+        int limit,
+        String nameLike,
+        String sortBy,
+        String sortDirection
+    ) {
+        CursorPageResponseDto<FollowResponse> responses =
+            followService.getFollowers(followeeId, cursor, idAfter, limit, nameLike, sortBy, sortDirection);
         return ResponseEntity.ok(responses);
     }
 
-    /**
-     * 팔로잉 목록 조회 (프로필 포함)
-     */
-    @GetMapping("/followings/{userId}")
-    public ResponseEntity<List<FollowingResponse>> getFollowings(@PathVariable UUID userId) {
-        List<FollowingResponse> responses = followService.getFollowings(userId);
+    @Override
+    public ResponseEntity<CursorPageResponseDto<FollowingResponse>> getFollowings(
+        UUID followerId,
+        String cursor,
+        UUID idAfter,
+        int limit,
+        String nameLike,
+        String sortBy,
+        String sortDirection
+    ) {
+        CursorPageResponseDto<FollowingResponse> responses =
+            followService.getFollowings(followerId, cursor, idAfter, limit, nameLike, sortBy, sortDirection);
         return ResponseEntity.ok(responses);
     }
 
-    /**
-     * 언팔로우(팔로우 취소)
-     */
-    @DeleteMapping
-    public ResponseEntity<Void> deleteFollow(@RequestBody FollowRequest request) {
+    @Override
+    public ResponseEntity<Void> deleteFollow(FollowRequest request) {
         followService.deleteFollow(request);
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * 팔로우 요약 정보 조회
-     */
-    @GetMapping("/summary/{userId}")
-    public ResponseEntity<FollowSummaryResponse> getFollowSummary(
-        @PathVariable UUID userId,
-        @RequestParam(required = false) UUID viewerId) {
+    @Override
+    public ResponseEntity<FollowSummaryResponse> getFollowSummary(UUID userId, UUID viewerId) {
         FollowSummaryResponse summary = followService.getFollowSummary(userId, viewerId);
         return ResponseEntity.ok(summary);
     }

--- a/src/main/java/com/onepiece/otboo/domain/follow/controller/api/FollowApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/controller/api/FollowApi.java
@@ -3,78 +3,55 @@ package com.onepiece.otboo.domain.follow.controller.api;
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
+import com.onepiece.otboo.global.dto.response.CursorPageResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Follow API", description = "팔로우 관련 API")
 @RequestMapping("/api/follows")
 public interface FollowApi {
 
-    @Operation(
-        summary = "팔로우 생성",
-        description = "사용자가 다른 사용자를 팔로우합니다.",
-        responses = {
-            @ApiResponse(responseCode = "201", description = "팔로우 생성 성공",
-                content = @Content(schema = @Schema(implementation = FollowResponse.class))),
-            @ApiResponse(responseCode = "400", description = "이미 팔로우 관계 존재 또는 잘못된 요청"),
-            @ApiResponse(responseCode = "404", description = "대상 사용자 없음")
-        }
-    )
+    @Operation(summary = "팔로우 생성", description = "사용자가 다른 사용자를 팔로우합니다.")
     @PostMapping
     ResponseEntity<FollowResponse> createFollow(@RequestBody FollowRequest request);
 
-    @Operation(
-        summary = "팔로워 목록 조회",
-        description = "특정 사용자를 팔로우하는 모든 사용자 목록을 조회합니다.",
-        responses = {
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                content = @Content(schema = @Schema(implementation = FollowResponse.class))),
-            @ApiResponse(responseCode = "404", description = "대상 사용자 없음")
-        }
-    )
+    @Operation(summary = "팔로워 목록 조회", description = "특정 사용자를 팔로우하는 모든 사용자 목록을 조회합니다.")
     @GetMapping("/followers/{userId}")
-    ResponseEntity<List<FollowResponse>> getFollowers(@PathVariable UUID userId);
+    ResponseEntity<CursorPageResponseDto<FollowResponse>> getFollowers(
+        @PathVariable("userId") UUID followeeId,
+        @RequestParam(required = false) String cursor,
+        @RequestParam(required = false) UUID idAfter,
+        @RequestParam(defaultValue = "10") int limit,
+        @RequestParam(required = false) String nameLike,
+        @RequestParam(defaultValue = "createdAt") String sortBy,
+        @RequestParam(defaultValue = "ASC") String sortDirection
+    );
 
-    @Operation(
-        summary = "팔로잉 목록 조회",
-        description = "특정 사용자가 팔로우하는 사용자 목록을 조회합니다.",
-        responses = {
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                content = @Content(schema = @Schema(implementation = FollowResponse.class))),
-            @ApiResponse(responseCode = "404", description = "대상 사용자 없음")
-        }
-    )
+    @Operation(summary = "팔로잉 목록 조회", description = "특정 사용자가 팔로우하는 사용자 목록을 조회합니다.")
     @GetMapping("/followings/{userId}")
-    ResponseEntity<List<FollowResponse>> getFollowings(@PathVariable UUID userId);
+    ResponseEntity<CursorPageResponseDto<FollowingResponse>> getFollowings(
+        @PathVariable("userId") UUID followerId,
+        @RequestParam(required = false) String cursor,
+        @RequestParam(required = false) UUID idAfter,
+        @RequestParam(defaultValue = "10") int limit,
+        @RequestParam(required = false) String nameLike,
+        @RequestParam(defaultValue = "createdAt") String sortBy,
+        @RequestParam(defaultValue = "ASC") String sortDirection
+    );
 
-    @Operation(
-        summary = "언팔로우",
-        description = "사용자가 특정 사용자를 언팔로우합니다.",
-        responses = {
-            @ApiResponse(responseCode = "204", description = "언팔로우 성공"),
-            @ApiResponse(responseCode = "404", description = "대상 사용자 없음")
-        }
-    )
+    @Operation(summary = "언팔로우", description = "사용자가 특정 사용자를 언팔로우합니다.")
     @DeleteMapping
     ResponseEntity<Void> deleteFollow(@RequestBody FollowRequest request);
 
-    @Operation(
-        summary = "팔로우 요약 조회",
-        description = "특정 사용자의 팔로워 수, 팔로잉 수, viewer 기준 팔로우 여부를 반환합니다.",
-        responses = {
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                content = @Content(schema = @Schema(implementation = FollowSummaryResponse.class))),
-            @ApiResponse(responseCode = "404", description = "대상 사용자 없음")
-        }
-    )
+    @Operation(summary = "팔로우 요약 조회", description = "팔로워 수, 팔로잉 수, viewer 기준 팔로우 여부를 반환합니다.")
     @GetMapping("/summary/{userId}")
     ResponseEntity<FollowSummaryResponse> getFollowSummary(
         @PathVariable UUID userId,

--- a/src/main/java/com/onepiece/otboo/domain/follow/dto/data/FollowData.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/dto/data/FollowData.java
@@ -1,16 +1,11 @@
 package com.onepiece.otboo.domain.follow.dto.data;
 
 import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@Builder
-@AllArgsConstructor
+public record FollowData(
+    UUID id,
+    UUID followerId,
+    UUID followingId
+) {
 
-public class FollowData {
-    private UUID id;
-    private UUID followerId;
-    private UUID followingId;
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/dto/request/FollowRequest.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/dto/request/FollowRequest.java
@@ -1,16 +1,10 @@
 package com.onepiece.otboo.domain.follow.dto.request;
 
-
 import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
+public record FollowRequest(
+    UUID followerId,
+    UUID followeeId
+) {
 
-public class FollowRequest {
-    private UUID followerId;
-    private UUID followingId;
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowResponse.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowResponse.java
@@ -1,17 +1,28 @@
 package com.onepiece.otboo.domain.follow.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import java.time.Instant;
-import java.util.UUID;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter
+import java.util.UUID;
+
 @Builder
-@AllArgsConstructor
+@Getter
 public class FollowResponse {
     private UUID id;
     private UUID followerId;
-    private UUID followingId;
+    private String nickname;
+    private String profileImageUrl;
     private Instant createdAt;
+
+    @QueryProjection
+    public FollowResponse(UUID id, UUID followerId, String nickname, String profileImageUrl, Instant createdAt) {
+        this.id = id;
+        this.followerId = followerId;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.createdAt = createdAt;
+    }
 }
+

--- a/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowSummaryResponse.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowSummaryResponse.java
@@ -1,23 +1,23 @@
 package com.onepiece.otboo.domain.follow.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.AccessLevel;
 
+import java.util.UUID;
+
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FollowSummaryResponse {
-
     private UUID userId;
     private long followerCount;
     private long followingCount;
-    
+
     @JsonProperty("isFollowing")
     private boolean isFollowing;
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowingResponse.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowingResponse.java
@@ -1,18 +1,26 @@
 package com.onepiece.otboo.domain.follow.dto.response;
 
-import java.time.Instant;
-import java.util.UUID;
-import lombok.AllArgsConstructor;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Getter;
+import java.time.Instant;
+import java.util.UUID;
 
-@Getter
 @Builder
-@AllArgsConstructor
+@Getter
 public class FollowingResponse {
     private UUID id;
     private UUID followingId;
     private String nickname;
     private String profileImage;
     private Instant createdAt;
+
+    @QueryProjection
+    public FollowingResponse(UUID id, UUID followingId, String nickname, String profileImage, Instant createdAt) {
+        this.id = id;
+        this.followingId = followingId;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowingResponse.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowingResponse.java
@@ -1,0 +1,4 @@
+package com.onepiece.otboo.domain.follow.dto.response;
+
+public class FollowingResponse {
+}

--- a/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowingResponse.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/dto/response/FollowingResponse.java
@@ -1,4 +1,18 @@
 package com.onepiece.otboo.domain.follow.dto.response;
 
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
 public class FollowingResponse {
+    private UUID id;
+    private UUID followingId;
+    private String nickname;
+    private String profileImage;
+    private Instant createdAt;
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/entity/Follow.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/entity/Follow.java
@@ -44,4 +44,16 @@ public class Follow extends BaseEntity {
             throw DuplicateFollowException.of(this.follower.getId(), this.following.getId());
         }
     }
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Follow)) return false;
+        Follow other = (Follow) o;
+        return getId() != null && getId().equals(other.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/entity/Follow.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/entity/Follow.java
@@ -1,20 +1,18 @@
 package com.onepiece.otboo.domain.follow.entity;
 
 import com.onepiece.otboo.domain.follow.exception.DuplicateFollowException;
-import com.onepiece.otboo.domain.follow.repository.FollowRepository;
 import com.onepiece.otboo.domain.user.entity.User;
 import com.onepiece.otboo.global.base.BaseEntity;
+import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 
 @Entity
 @Table(
@@ -25,8 +23,6 @@ import jakarta.persistence.UniqueConstraint;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 public class Follow extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -36,6 +32,12 @@ public class Follow extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_id", nullable = false)
     private User following;
+
+    @Builder
+    public Follow(User follower, User following) {
+        this.follower = follower;
+        this.following = following;
+    }
 
     public void validateDuplicate(boolean alreadyExists) {
         if (alreadyExists) {

--- a/src/main/java/com/onepiece/otboo/domain/follow/exception/DuplicateFollowException.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/exception/DuplicateFollowException.java
@@ -6,8 +6,8 @@ import java.util.UUID;
 
 public class DuplicateFollowException extends FollowException {
 
-    public DuplicateFollowException() {
-        super(ErrorCode.DUPLICATE_FOLLOW);
+    public DuplicateFollowException(ErrorCode errorCode) {
+        super(errorCode);
     }
 
     private DuplicateFollowException(Map<String, Object> details) {

--- a/src/main/java/com/onepiece/otboo/domain/follow/mapper/FollowMapper.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/mapper/FollowMapper.java
@@ -9,12 +9,13 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface FollowMapper {
 
+    @Mapping(source = "id", target = "id")
     @Mapping(source = "follower.id", target = "followerId")
-    @Mapping(source = "following.id", target = "followingId")
+    @Mapping(source = "createdAt", target = "createdAt")
     FollowResponse toResponse(Follow follow);
 
+    @Mapping(source = "id", target = "id")
     @Mapping(source = "follower.id", target = "followerId")
     @Mapping(source = "following.id", target = "followingId")
     FollowData toData(Follow follow);
-
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepository.java
@@ -1,10 +1,13 @@
 package com.onepiece.otboo.domain.follow.repository;
 
+import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
 import com.onepiece.otboo.domain.follow.entity.Follow;
 import com.onepiece.otboo.domain.user.entity.User;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FollowRepository extends JpaRepository<Follow, UUID> {
 
@@ -19,4 +22,13 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
     long countByFollowing(User following);
 
     long countByFollower(User follower);
+
+    @Query("SELECT new com.onepiece.otboo.domain.follow.dto.response.FollowingResponse(" +
+        "f.id, u.id, p.nickname, p.profileImageUrl, f.createdAt) " +
+        "FROM Follow f " +
+        "JOIN f.following u " +
+        "JOIN Profile p ON p.user = u " +
+        "WHERE f.follower = :user")
+    List<FollowingResponse> findFollowingsWithProfile(@Param("user") User user);
+
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepository.java
@@ -1,15 +1,12 @@
 package com.onepiece.otboo.domain.follow.repository;
 
-import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
 import com.onepiece.otboo.domain.follow.entity.Follow;
 import com.onepiece.otboo.domain.user.entity.User;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface FollowRepository extends JpaRepository<Follow, UUID> {
+public interface FollowRepository extends JpaRepository<Follow, UUID>, FollowRepositoryCustom {
 
     boolean existsByFollowerAndFollowing(User follower, User following);
 
@@ -22,13 +19,5 @@ public interface FollowRepository extends JpaRepository<Follow, UUID> {
     long countByFollowing(User following);
 
     long countByFollower(User follower);
-
-    @Query("SELECT new com.onepiece.otboo.domain.follow.dto.response.FollowingResponse(" +
-        "f.id, u.id, p.nickname, p.profileImageUrl, f.createdAt) " +
-        "FROM Follow f " +
-        "JOIN f.following u " +
-        "JOIN Profile p ON p.user = u " +
-        "WHERE f.follower = :user")
-    List<FollowingResponse> findFollowingsWithProfile(@Param("user") User user);
 
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryCustom.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryCustom.java
@@ -1,4 +1,31 @@
 package com.onepiece.otboo.domain.follow.repository;
 
-public class FollowRepositoryCustom {
+import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
+import com.onepiece.otboo.domain.user.entity.User;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface FollowRepositoryCustom {
+
+    List<FollowResponse> findFollowersWithProfileCursor(
+        User followee,
+        String cursor,
+        UUID idAfter,
+        int limit,
+        String nameLike,
+        String sortBy,
+        String sortDirection
+    );
+
+    List<FollowingResponse> findFollowingsWithProfileCursor(
+        User follower,
+        String cursor,
+        UUID idAfter,
+        int limit,
+        String nameLike,
+        String sortBy,
+        String sortDirection
+    );
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryCustom.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.onepiece.otboo.domain.follow.repository;
+
+public class FollowRepositoryCustom {
+}

--- a/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryImpl.java
@@ -1,4 +1,132 @@
 package com.onepiece.otboo.domain.follow.repository;
 
-public class FollowRepositoryImpl {
+import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
+import com.onepiece.otboo.domain.follow.dto.response.QFollowResponse;
+import com.onepiece.otboo.domain.follow.dto.response.QFollowingResponse;
+import com.onepiece.otboo.domain.follow.entity.QFollow;
+import com.onepiece.otboo.domain.profile.entity.QProfile;
+import com.onepiece.otboo.domain.user.entity.QUser;
+import com.onepiece.otboo.domain.user.entity.User;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class FollowRepositoryImpl implements FollowRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<FollowingResponse> findFollowingsWithProfileCursor(
+        User follower,
+        String cursor,
+        UUID idAfter,
+        int limit,
+        String nameLike,
+        String sortBy,
+        String sortDirection
+    ) {
+        QFollow follow = QFollow.follow;
+        QUser user = QUser.user;
+        QProfile profile = QProfile.profile;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(follow.follower.eq(follower));
+
+        if (nameLike != null && !nameLike.isBlank()) {
+            builder.and(profile.nickname.containsIgnoreCase(nameLike));
+        }
+
+        if (cursor != null && idAfter != null) {
+            Instant cursorTime = Instant.parse(cursor);
+            if ("ASC".equalsIgnoreCase(sortDirection)) {
+                builder.and(follow.createdAt.gt(cursorTime)
+                    .or(follow.createdAt.eq(cursorTime).and(follow.id.gt(idAfter))));
+            } else {
+                builder.and(follow.createdAt.lt(cursorTime)
+                    .or(follow.createdAt.eq(cursorTime).and(follow.id.lt(idAfter))));
+            }
+        }
+
+        OrderSpecifier<?> orderSpecifier =
+            "ASC".equalsIgnoreCase(sortDirection)
+                ? follow.createdAt.asc()
+                : follow.createdAt.desc();
+
+        return queryFactory
+            .select(new QFollowingResponse(
+                follow.id,
+                user.id,
+                profile.nickname,
+                profile.profileImageUrl,
+                follow.createdAt
+            ))
+            .from(follow)
+            .join(follow.following, user)
+            .leftJoin(profile).on(profile.user.eq(user))
+            .where(builder)
+            .orderBy(orderSpecifier, follow.id.asc())
+            .limit(limit + 1)
+            .fetch();
+    }
+
+    @Override
+    public List<FollowResponse> findFollowersWithProfileCursor(
+        User followee,
+        String cursor,
+        UUID idAfter,
+        int limit,
+        String nameLike,
+        String sortBy,
+        String sortDirection
+    ) {
+        QFollow follow = QFollow.follow;
+        QUser user = QUser.user;
+        QProfile profile = QProfile.profile;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(follow.following.eq(followee));
+
+        if (nameLike != null && !nameLike.isBlank()) {
+            builder.and(profile.nickname.containsIgnoreCase(nameLike));
+        }
+
+        if (cursor != null && idAfter != null) {
+            Instant cursorTime = Instant.parse(cursor);
+            if ("ASC".equalsIgnoreCase(sortDirection)) {
+                builder.and(follow.createdAt.gt(cursorTime)
+                    .or(follow.createdAt.eq(cursorTime).and(follow.id.gt(idAfter))));
+            } else {
+                builder.and(follow.createdAt.lt(cursorTime)
+                    .or(follow.createdAt.eq(cursorTime).and(follow.id.lt(idAfter))));
+            }
+        }
+
+        OrderSpecifier<?> orderSpecifier =
+            "ASC".equalsIgnoreCase(sortDirection)
+                ? follow.createdAt.asc()
+                : follow.createdAt.desc();
+
+        return queryFactory
+            .select(new QFollowResponse(
+                follow.id,
+                user.id,
+                profile.nickname,
+                profile.profileImageUrl,
+                follow.createdAt
+            ))
+            .from(follow)
+            .join(follow.follower, user)
+            .leftJoin(profile).on(profile.user.eq(user))
+            .where(builder)
+            .orderBy(orderSpecifier, follow.id.asc())
+            .limit(limit + 1)
+            .fetch();
+    }
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.onepiece.otboo.domain.follow.repository;
+
+public class FollowRepositoryImpl {
+}

--- a/src/main/java/com/onepiece/otboo/domain/follow/service/FollowService.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/service/FollowService.java
@@ -4,17 +4,33 @@ import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
+import com.onepiece.otboo.global.dto.response.CursorPageResponseDto;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface FollowService {
 
     FollowResponse createFollow(FollowRequest request);
 
-    List<FollowResponse> getFollowers(UUID userId);
+    CursorPageResponseDto<FollowResponse> getFollowers(
+        UUID followeeId,
+        String cursor,
+        UUID idAfter,
+        int limit,
+        String nameLike,
+        String sortBy,
+        String sortDirection
+    );
 
-    List<FollowingResponse> getFollowings(UUID userId);
+    CursorPageResponseDto<FollowingResponse> getFollowings(
+        UUID followerId,
+        String cursor,
+        UUID idAfter,
+        int limit,
+        String nameLike,
+        String sortBy,
+        String sortDirection
+    );
 
     void deleteFollow(FollowRequest request);
 

--- a/src/main/java/com/onepiece/otboo/domain/follow/service/FollowService.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/service/FollowService.java
@@ -2,8 +2,9 @@ package com.onepiece.otboo.domain.follow.service;
 
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
-
 import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -13,10 +14,9 @@ public interface FollowService {
 
     List<FollowResponse> getFollowers(UUID userId);
 
-    List<FollowResponse> getFollowings(UUID userId);
+    List<FollowingResponse> getFollowings(UUID userId);
 
     void deleteFollow(FollowRequest request);
 
     FollowSummaryResponse getFollowSummary(UUID userId, UUID viewerId);
-
 }

--- a/src/main/java/com/onepiece/otboo/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/service/FollowServiceImpl.java
@@ -3,20 +3,20 @@ package com.onepiece.otboo.domain.follow.service;
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
 import com.onepiece.otboo.domain.follow.entity.Follow;
-import com.onepiece.otboo.domain.follow.exception.DuplicateFollowException;
 import com.onepiece.otboo.domain.follow.mapper.FollowMapper;
 import com.onepiece.otboo.domain.follow.repository.FollowRepository;
 import com.onepiece.otboo.domain.user.entity.User;
 import com.onepiece.otboo.domain.user.exception.UserNotFoundException;
 import com.onepiece.otboo.domain.user.repository.UserRepository;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -57,13 +57,11 @@ public class FollowServiceImpl implements FollowService {
     }
 
     @Override
-    public List<FollowResponse> getFollowings(UUID userId) {
+    public List<FollowingResponse> getFollowings(UUID userId) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> UserNotFoundException.byId(userId));
 
-        return followRepository.findByFollower(user).stream()
-            .map(followMapper::toResponse)
-            .collect(Collectors.toList());
+        return followRepository.findFollowingsWithProfile(user);
     }
 
     @Override

--- a/src/main/java/com/onepiece/otboo/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/follow/service/FollowServiceImpl.java
@@ -5,12 +5,14 @@ import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
 import com.onepiece.otboo.domain.follow.entity.Follow;
+import com.onepiece.otboo.domain.follow.exception.DuplicateFollowException;
 import com.onepiece.otboo.domain.follow.mapper.FollowMapper;
 import com.onepiece.otboo.domain.follow.repository.FollowRepository;
 import com.onepiece.otboo.domain.user.entity.User;
 import com.onepiece.otboo.domain.user.exception.UserNotFoundException;
 import com.onepiece.otboo.domain.user.repository.UserRepository;
-import java.util.stream.Collectors;
+import com.onepiece.otboo.global.dto.response.CursorPageResponseDto;
+import com.onepiece.otboo.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,54 +29,144 @@ public class FollowServiceImpl implements FollowService {
     private final UserRepository userRepository;
     private final FollowMapper followMapper;
 
+    /**
+     * 팔로우 생성
+     */
     @Override
     public FollowResponse createFollow(FollowRequest request) {
-        User follower = userRepository.findById(request.getFollowerId())
-            .orElseThrow(() -> UserNotFoundException.byId(request.getFollowerId()));
-        User following = userRepository.findById(request.getFollowingId())
-            .orElseThrow(() -> UserNotFoundException.byId(request.getFollowingId()));
+        User follower = userRepository.findById(request.followerId())
+            .orElseThrow(() -> UserNotFoundException.byId(request.followerId()));
 
-        Follow follow = Follow.builder()
-            .follower(follower)
-            .following(following)
-            .build();
+        User followee = userRepository.findById(request.followeeId())
+            .orElseThrow(() -> UserNotFoundException.byId(request.followeeId()));
 
-        boolean alreadyExists = followRepository.existsByFollowerAndFollowing(follower, following);
-        follow.validateDuplicate(alreadyExists);
+        if (followRepository.existsByFollowerAndFollowing(follower, followee)) {
+            throw new DuplicateFollowException(ErrorCode.DUPLICATE_FOLLOW);
+        }
 
-        Follow saved = followRepository.save(follow);
+        Follow saved = followRepository.save(
+            Follow.builder()
+                .follower(follower)
+                .following(followee)
+                .build()
+        );
+
         return followMapper.toResponse(saved);
     }
 
+    /**
+     * 팔로워 목록 조회 (커서 기반 페이지네이션)
+     */
     @Override
-    public List<FollowResponse> getFollowers(UUID userId) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> UserNotFoundException.byId(userId));
+    @Transactional(readOnly = true)
+    public CursorPageResponseDto<FollowResponse> getFollowers(
+        UUID followeeId,
+        String cursor,
+        UUID idAfter,
+        int limit,
+        String nameLike,
+        String sortBy,
+        String sortDirection
+    ) {
+        User followee = userRepository.findById(followeeId)
+            .orElseThrow(() -> UserNotFoundException.byId(followeeId));
 
-        return followRepository.findByFollowing(user).stream()
-            .map(followMapper::toResponse)
-            .collect(Collectors.toList());
+        List<FollowResponse> results = followRepository.findFollowersWithProfileCursor(
+            followee, cursor, idAfter, limit, nameLike, sortBy, sortDirection
+        );
+
+        boolean hasNext = results.size() > limit;
+        if (hasNext) {
+            results = results.subList(0, limit);
+        }
+
+        String nextCursor = null;
+        String nextIdAfter = null;
+        if (!results.isEmpty()) {
+            FollowResponse last = results.get(results.size() - 1);
+            nextCursor = last.getCreatedAt().toString();
+            nextIdAfter = last.getId().toString();
+        }
+
+        long totalCount = followRepository.countByFollowing(followee);
+
+        return new CursorPageResponseDto<>(
+            results,
+            nextCursor,
+            nextIdAfter,
+            hasNext,
+            totalCount,
+            sortBy,
+            sortDirection
+        );
     }
 
+    /**
+     * 팔로잉 목록 조회 (프로필 포함, 커서 기반 페이지네이션)
+     */
     @Override
-    public List<FollowingResponse> getFollowings(UUID userId) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> UserNotFoundException.byId(userId));
+    @Transactional(readOnly = true)
+    public CursorPageResponseDto<FollowingResponse> getFollowings(
+        UUID followerId,
+        String cursor,
+        UUID idAfter,
+        int limit,
+        String nameLike,
+        String sortBy,
+        String sortDirection
+    ) {
+        User follower = userRepository.findById(followerId)
+            .orElseThrow(() -> UserNotFoundException.byId(followerId));
 
-        return followRepository.findFollowingsWithProfile(user);
+        List<FollowingResponse> results = followRepository.findFollowingsWithProfileCursor(
+            follower, cursor, idAfter, limit, nameLike, sortBy, sortDirection
+        );
+
+        boolean hasNext = results.size() > limit;
+        if (hasNext) {
+            results = results.subList(0, limit);
+        }
+
+        String nextCursor = null;
+        String nextIdAfter = null;
+        if (!results.isEmpty()) {
+            FollowingResponse last = results.get(results.size() - 1);
+            nextCursor = last.getCreatedAt().toString();
+            nextIdAfter = last.getId().toString();
+        }
+
+        long totalCount = followRepository.countByFollower(follower);
+
+        return new CursorPageResponseDto<>(
+            results,
+            nextCursor,
+            nextIdAfter,
+            hasNext,
+            totalCount,
+            sortBy,
+            sortDirection
+        );
     }
 
+    /**
+     * 언팔로우 (팔로우 취소)
+     */
     @Override
     public void deleteFollow(FollowRequest request) {
-        User follower = userRepository.findById(request.getFollowerId())
-            .orElseThrow(() -> UserNotFoundException.byId(request.getFollowerId()));
-        User following = userRepository.findById(request.getFollowingId())
-            .orElseThrow(() -> UserNotFoundException.byId(request.getFollowingId()));
+        User follower = userRepository.findById(request.followerId())
+            .orElseThrow(() -> UserNotFoundException.byId(request.followerId()));
 
-        followRepository.deleteByFollowerAndFollowing(follower, following);
+        User followee = userRepository.findById(request.followeeId())
+            .orElseThrow(() -> UserNotFoundException.byId(request.followeeId()));
+
+        followRepository.deleteByFollowerAndFollowing(follower, followee);
     }
 
+    /**
+     * 팔로우 요약 정보 조회
+     */
     @Override
+    @Transactional(readOnly = true)
     public FollowSummaryResponse getFollowSummary(UUID userId, UUID viewerId) {
         User targetUser = userRepository.findById(userId)
             .orElseThrow(() -> UserNotFoundException.byId(userId));
@@ -89,11 +181,11 @@ public class FollowServiceImpl implements FollowService {
             isFollowing = followRepository.existsByFollowerAndFollowing(viewer, targetUser);
         }
 
-        return FollowSummaryResponse.builder()
-            .userId(userId)
-            .followerCount(followerCount)
-            .followingCount(followingCount)
-            .isFollowing(isFollowing)
-            .build();
+        return new FollowSummaryResponse(
+            userId,
+            followerCount,
+            followingCount,
+            isFollowing
+        );
     }
 }

--- a/src/test/java/com/onepiece/otboo/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/follow/controller/FollowControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
 import com.onepiece.otboo.domain.follow.service.FollowService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -91,18 +92,23 @@ class FollowControllerTest {
     void getFollowings_success() throws Exception {
 
         UUID userId = UUID.randomUUID();
-        FollowResponse response = new FollowResponse(
-            UUID.randomUUID(),
-            userId,
-            UUID.randomUUID(),
-            Instant.now()
-        );
+        UUID followingId = UUID.randomUUID();
+
+        FollowingResponse response = FollowingResponse.builder()
+            .id(UUID.randomUUID())
+            .followingId(followingId)
+            .nickname("test-nickname")
+            .profileImage("test-image-url")
+            .createdAt(Instant.now())
+            .build();
 
         given(followService.getFollowings(eq(userId))).willReturn(List.of(response));
 
         mockMvc.perform(get("/api/follows/followings/{userId}", userId))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$[0].followerId").value(userId.toString()));
+            .andExpect(jsonPath("$[0].followingId").value(followingId.toString()))
+            .andExpect(jsonPath("$[0].nickname").value("test-nickname"))
+            .andExpect(jsonPath("$[0].profileImage").value("test-image-url"));
     }
 
     @Test

--- a/src/test/java/com/onepiece/otboo/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/follow/controller/FollowControllerTest.java
@@ -6,6 +6,7 @@ import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowSummaryResponse;
 import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
 import com.onepiece.otboo.domain.follow.service.FollowService;
+import com.onepiece.otboo.global.dto.response.CursorPageResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,14 +21,12 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(FollowController.class)
 @AutoConfigureMockMvc(addFilters = false) // Security 무시
@@ -46,17 +45,17 @@ class FollowControllerTest {
     @Test
     @DisplayName("팔로우 생성 성공")
     void createFollow_success() throws Exception {
-
         UUID followerId = UUID.randomUUID();
-        UUID followingId = UUID.randomUUID();
-        FollowRequest request = new FollowRequest(followerId, followingId);
+        UUID followeeId = UUID.randomUUID();
+        FollowRequest request = new FollowRequest(followerId, followeeId);
 
-        FollowResponse response = new FollowResponse(
-            UUID.randomUUID(),
-            followerId,
-            followingId,
-            Instant.now()
-        );
+        FollowResponse response = FollowResponse.builder()
+            .id(UUID.randomUUID())
+            .followerId(followerId)
+            .nickname("팔로워닉네임")
+            .profileImageUrl("follower.png")
+            .createdAt(Instant.now())
+            .build();
 
         given(followService.createFollow(any(FollowRequest.class))).willReturn(response);
 
@@ -65,59 +64,67 @@ class FollowControllerTest {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.followerId").value(followerId.toString()))
-            .andExpect(jsonPath("$.followingId").value(followingId.toString()));
+            .andExpect(jsonPath("$.nickname").value("팔로워닉네임"));
     }
 
     @Test
-    @DisplayName("팔로워 목록 조회 성공")
+    @DisplayName("팔로워 목록 조회 성공 (커서 기반)")
     void getFollowers_success() throws Exception {
-
         UUID userId = UUID.randomUUID();
-        FollowResponse response = new FollowResponse(
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            userId,
-            Instant.now()
-        );
 
-        given(followService.getFollowers(eq(userId))).willReturn(List.of(response));
-
-        mockMvc.perform(get("/api/follows/followers/{userId}", userId))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$[0].followingId").value(userId.toString()));
-    }
-
-    @Test
-    @DisplayName("팔로잉 목록 조회 성공")
-    void getFollowings_success() throws Exception {
-
-        UUID userId = UUID.randomUUID();
-        UUID followingId = UUID.randomUUID();
-
-        FollowingResponse response = FollowingResponse.builder()
+        FollowResponse followResponse = FollowResponse.builder()
             .id(UUID.randomUUID())
-            .followingId(followingId)
-            .nickname("test-nickname")
-            .profileImage("test-image-url")
+            .followerId(UUID.randomUUID())
+            .nickname("팔로워닉네임")
+            .profileImageUrl("profile.png")
             .createdAt(Instant.now())
             .build();
 
-        given(followService.getFollowings(eq(userId))).willReturn(List.of(response));
+        CursorPageResponseDto<FollowResponse> mockResponse =
+            new CursorPageResponseDto<>(List.of(followResponse), "cursor123", UUID.randomUUID().toString(),
+                false, 1L, "createdAt", "ASC");
+
+        given(followService.getFollowers(eq(userId), any(), any(), anyInt(), any(), any(), any()))
+            .willReturn(mockResponse);
+
+        mockMvc.perform(get("/api/follows/followers/{userId}", userId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data[0].nickname").value("팔로워닉네임"));
+    }
+
+    @Test
+    @DisplayName("팔로잉 목록 조회 성공 (커서 기반)")
+    void getFollowings_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID followingId = UUID.randomUUID();
+
+        FollowingResponse followingResponse = FollowingResponse.builder()
+            .id(UUID.randomUUID())
+            .followingId(followingId)
+            .nickname("팔로잉닉네임")
+            .profileImage("profile.png")
+            .createdAt(Instant.now())
+            .build();
+
+        CursorPageResponseDto<FollowingResponse> mockResponse =
+            new CursorPageResponseDto<>(List.of(followingResponse), "cursor456", UUID.randomUUID().toString(),
+                false, 1L, "createdAt", "ASC");
+
+        given(followService.getFollowings(eq(userId), any(), any(), anyInt(), any(), any(), any()))
+            .willReturn(mockResponse);
 
         mockMvc.perform(get("/api/follows/followings/{userId}", userId))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$[0].followingId").value(followingId.toString()))
-            .andExpect(jsonPath("$[0].nickname").value("test-nickname"))
-            .andExpect(jsonPath("$[0].profileImage").value("test-image-url"));
+            .andExpect(jsonPath("$.data[0].followingId").value(followingId.toString()))
+            .andExpect(jsonPath("$.data[0].nickname").value("팔로잉닉네임"));
     }
 
     @Test
     @DisplayName("언팔로우 성공")
     void deleteFollow_success() throws Exception {
-
         UUID followerId = UUID.randomUUID();
-        UUID followingId = UUID.randomUUID();
-        FollowRequest request = new FollowRequest(followerId, followingId);
+        UUID followeeId = UUID.randomUUID();
+        FollowRequest request = new FollowRequest(followerId, followeeId);
 
         doNothing().when(followService).deleteFollow(any(FollowRequest.class));
 
@@ -126,10 +133,10 @@ class FollowControllerTest {
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isNoContent());
     }
+
     @Test
     @DisplayName("팔로우 요약 조회 성공")
     void getFollowSummary_success() throws Exception {
-
         UUID userId = UUID.randomUUID();
         UUID viewerId = UUID.randomUUID();
 
@@ -151,5 +158,4 @@ class FollowControllerTest {
             .andExpect(jsonPath("$.followingCount").value(3))
             .andExpect(jsonPath("$.isFollowing").value(true));
     }
-
 }

--- a/src/test/java/com/onepiece/otboo/domain/follow/entity/FollowTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/follow/entity/FollowTest.java
@@ -7,39 +7,49 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class FollowTest {
 
+    private User createUser(String email) {
+        return User.builder()
+            .provider(Provider.LOCAL)
+            .providerUserId(UUID.randomUUID().toString())
+            .email(email)
+            .password("password")
+            .locked(false)
+            .role(Role.USER)
+            .build();
+    }
+
     @Test
     @DisplayName("Follow 엔티티를 빌더로 생성할 수 있다")
     void createFollowEntity_success() {
-        User follower = User.builder()
-            .provider(Provider.LOCAL)
-            .providerUserId("follower-" + UUID.randomUUID())
-            .email("follower@test.com")
-            .password("password123")
-            .locked(false)
-            .role(Role.USER)
-            .build();
-
-        User following = User.builder()
-            .provider(Provider.LOCAL)
-            .providerUserId("following-" + UUID.randomUUID())
-            .email("following@test.com")
-            .password("password123")
-            .locked(false)
-            .role(Role.USER)
-            .build();
+        User follower = createUser("follower@test.com");
+        User following = createUser("following@test.com");
 
         Follow follow = Follow.builder()
             .follower(follower)
             .following(following)
             .build();
 
-        assertThat(follow).isNotNull();
         assertThat(follow.getFollower().getEmail()).isEqualTo("follower@test.com");
         assertThat(follow.getFollowing().getEmail()).isEqualTo("following@test.com");
+    }
+
+    @Test
+    @DisplayName("equals/hashCode 동작 확인")
+    void equalsAndHashCode_success() {
+        Follow f1 = Follow.builder().build();
+        Follow f2 = Follow.builder().build();
+
+        UUID id = UUID.randomUUID();
+        ReflectionTestUtils.setField(f1, "id", id);
+        ReflectionTestUtils.setField(f2, "id", id);
+
+        assertThat(f1).isEqualTo(f2);
+        assertThat(f1.hashCode()).isEqualTo(f2.hashCode());
     }
 }

--- a/src/test/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/follow/repository/FollowRepositoryTest.java
@@ -9,12 +9,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.UUID;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,16 +42,13 @@ class FollowRepositoryTest {
     @Test
     @DisplayName("팔로우 저장 및 조회 성공")
     void saveAndFindFollow_success() {
-
         User follower = userRepository.save(createUser("follower@test.com"));
         User following = userRepository.save(createUser("following@test.com"));
 
-        Follow follow = Follow.builder()
+        Follow saved = followRepository.save(Follow.builder()
             .follower(follower)
             .following(following)
-            .build();
-
-        Follow saved = followRepository.save(follow);
+            .build());
 
         assertThat(saved.getId()).isNotNull();
         assertThat(saved.getFollower().getEmail()).isEqualTo("follower@test.com");
@@ -62,7 +58,6 @@ class FollowRepositoryTest {
     @Test
     @DisplayName("follower 기준으로 Follow 조회")
     void findByFollower_success() {
-
         User follower = userRepository.save(createUser("f1@test.com"));
         User following1 = userRepository.save(createUser("f2@test.com"));
         User following2 = userRepository.save(createUser("f3@test.com"));
@@ -93,7 +88,6 @@ class FollowRepositoryTest {
     @Test
     @DisplayName("이미 팔로우 관계가 존재하는지 확인")
     void existsByFollowerAndFollowing_success() {
-
         User follower = userRepository.save(createUser("f1@test.com"));
         User following = userRepository.save(createUser("f2@test.com"));
         followRepository.save(Follow.builder().follower(follower).following(following).build());
@@ -106,7 +100,6 @@ class FollowRepositoryTest {
     @Test
     @DisplayName("팔로우 삭제 성공")
     void deleteByFollowerAndFollowing_success() {
-
         User follower = userRepository.save(createUser("f1@test.com"));
         User following = userRepository.save(createUser("f2@test.com"));
         followRepository.save(Follow.builder().follower(follower).following(following).build());
@@ -118,9 +111,8 @@ class FollowRepositoryTest {
     }
 
     @Test
-    @DisplayName("특정 사용자의 팔로워 수를 조회할 수 있다")
+    @DisplayName("특정 사용자의 팔로워 수 조회")
     void countByFollowing_success() {
-
         User following = userRepository.save(createUser("target@test.com"));
         User follower1 = userRepository.save(createUser("f1@test.com"));
         User follower2 = userRepository.save(createUser("f2@test.com"));
@@ -133,9 +125,8 @@ class FollowRepositoryTest {
     }
 
     @Test
-    @DisplayName("특정 사용자의 팔로잉 수를 조회할 수 있다")
+    @DisplayName("특정 사용자의 팔로잉 수 조회")
     void countByFollower_success() {
-
         User follower = userRepository.save(createUser("f1@test.com"));
         User following1 = userRepository.save(createUser("f2@test.com"));
         User following2 = userRepository.save(createUser("f3@test.com"));
@@ -146,5 +137,4 @@ class FollowRepositoryTest {
 
         assertThat(count).isEqualTo(2);
     }
-
 }

--- a/src/test/java/com/onepiece/otboo/domain/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/follow/service/FollowServiceImplTest.java
@@ -2,6 +2,7 @@ package com.onepiece.otboo.domain.follow.service;
 
 import com.onepiece.otboo.domain.follow.dto.request.FollowRequest;
 import com.onepiece.otboo.domain.follow.dto.response.FollowResponse;
+import com.onepiece.otboo.domain.follow.dto.response.FollowingResponse;
 import com.onepiece.otboo.domain.follow.entity.Follow;
 import com.onepiece.otboo.domain.follow.exception.DuplicateFollowException;
 import com.onepiece.otboo.domain.follow.mapper.FollowMapper;
@@ -142,24 +143,21 @@ class FollowServiceImplTest {
     }
 
     @Test
-    @DisplayName("팔로잉 목록 조회 성공")
+    @DisplayName("팔로잉 목록 조회 성공 (프로필 포함)")
     void getFollowings_success() {
-
         UUID userId = UUID.randomUUID();
         given(userRepository.findById(userId)).willReturn(Optional.of(follower));
-        given(followRepository.findByFollower(follower)).willReturn(List.of(follow));
-        given(followMapper.toResponse(follow)).willReturn(
-            FollowResponse.builder()
-                .id(UUID.randomUUID())
-                .followerId(follower.getId())
-                .followingId(following.getId())
-                .createdAt(Instant.now())
-                .build()
-        );
 
-        List<FollowResponse> responses = followService.getFollowings(userId);
+        FollowingResponse followingResponse = new FollowingResponse(
+            UUID.randomUUID(), following.getId(), "팔로잉닉네임", "profile.png", Instant.now()
+        );
+        given(followRepository.findFollowingsWithProfile(follower))
+            .willReturn(List.of(followingResponse));
+
+        List<FollowingResponse> responses = followService.getFollowings(userId);
 
         assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getNickname()).isEqualTo("팔로잉닉네임");
     }
 
     @Test

--- a/src/test/java/com/onepiece/otboo/domain/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/follow/service/FollowServiceImplTest.java
@@ -110,6 +110,16 @@ class FollowServiceImplTest {
     }
 
     @Test
+    @DisplayName("팔로우 생성 실패 - 존재하지 않는 유저")
+    void createFollow_fail_userNotFound() {
+        FollowRequest request = new FollowRequest(UUID.randomUUID(), UUID.randomUUID());
+        given(userRepository.findById(request.followerId())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> followService.createFollow(request))
+            .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
     @DisplayName("이미 팔로우 했을 경우 예외 발생")
     void createFollow_alreadyExists_throwsException() {
         FollowRequest request = new FollowRequest(follower.getId(), following.getId());
@@ -182,6 +192,17 @@ class FollowServiceImplTest {
 
         verify(followRepository).deleteByFollowerAndFollowing(follower, following);
     }
+
+    @Test
+    @DisplayName("언팔로우 실패 - 대상 유저 없음")
+    void deleteFollow_fail_userNotFound() {
+        FollowRequest request = new FollowRequest(follower.getId(), UUID.randomUUID());
+        given(userRepository.findById(request.followeeId())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> followService.deleteFollow(request))
+            .isInstanceOf(UserNotFoundException.class);
+    }
+
 
     @Test
     @DisplayName("팔로우 요약 조회 성공 - viewer가 팔로우 중일 때")


### PR DESCRIPTION
## 📌 작업 개요

- 사용자 팔로잉(Following) 목록 조회 기능 구현

## ✅ 완료한 작업

- FollowingResponse DTO 작성 (닉네임, 프로필 이미지 포함)
- FollowRepository에 JPQL 쿼리 추가 (findFollowingsWithProfile)
- FollowService / FollowServiceImpl 수정 → FollowingResponse 반환
- FollowController API 엔드포인트 수정 (GET /api/follows/followings/{userId})
- FollowServiceImplTest, FollowControllerTest 단위 테스트 수정 및 통과 확인

## 🧪 테스트 결과

- 로컬 테스트 완료

## ⚠️ 기타 참고 사항

<img width="1310" height="864" alt="스크린샷 2025-09-23 오전 10 29 52" src="https://github.com/user-attachments/assets/ae490c07-8f7f-4f2e-be58-9b75193455e1" />


---

##

Related Issue #55 

Closes #55 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 팔로워/팔로잉 목록에 커서 기반 페이지네이션(검색·정렬·한도 지원) 및 페이지 메타데이터 제공.
  - 목록 항목에 닉네임·프로필 이미지 포함, 팔로잉 전용 응답 형식 추가.
  - 팔로우 요약 조회에 viewerId 옵션 추가로 상대방 팔로우 여부 확인 가능.

- **Bug Fixes**
  - 중복 팔로우 방지 강화 및 명확한 오류 반환.

- **Refactor**
  - 요청/응답 모델을 불변형으로 정비(레코드/DTO 개선) 및 내부 API 정리.

- **Tests**
  - 페이징·응답 형식 반영한 단위/통합 테스트 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->