### PR TITLE
 [Feature] 어드민 기능

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       TEMP_PASSWORD_CHARSET: ${{ secrets.TEMP_PASSWORD_CHARSET }}
       TEMP_PASSWORD_SPECIAL_CHARSET: ${{ secrets.TEMP_PASSWORD_SPECIAL_CHARSET }}
       SERVICE_API_KEY: ${{ secrets.SERVICE_API_KEY}}
+      ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+      ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/src/integrationTest/java/com/onepiece/otboo/domain/auth/AdminFeatureIntegrationTest.java
+++ b/src/integrationTest/java/com/onepiece/otboo/domain/auth/AdminFeatureIntegrationTest.java
@@ -1,0 +1,145 @@
+package com.onepiece.otboo.domain.auth;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+class AdminFeatureIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Value("${otboo.admin.email}")
+    private String adminEmail;
+    @Value("${otboo.admin.password}")
+    private String adminPassword;
+
+    @Test
+    void 서버_시작시_어드민_계정_자동_초기화() throws Exception {
+        User admin = userRepository.findByEmail(adminEmail).orElse(null);
+        Assertions.assertNotNull(admin);
+        Assertions.assertEquals("ADMIN", admin.getRole().name());
+        Assertions.assertTrue(passwordEncoder.matches(adminPassword, admin.getPassword()));
+    }
+
+    @Test
+    void 사용자_권한_변경_시_자동_로그아웃() throws Exception {
+        TestUserContext user = registerAndLogin("user1@otboo.com", "user1Pw!", "테스트유저1");
+        String changeRolePayload = "{\"role\":\"ADMIN\"}";
+        String adminToken = getAdminToken();
+        mockMvc.perform(patch("/api/users/" + user.userId + "/role")
+                .header("Authorization", adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(changeRolePayload)
+                .with(csrf()))
+            .andExpect(status().isOk());
+        mockMvc.perform(get("/api/users/" + user.userId)
+                .header("Authorization", user.token))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 계정_잠금_및_로그인_불가_자동_로그아웃() throws Exception {
+        TestUserContext user = registerAndLogin("user2@otboo.com", "user2pw!", "테스트유저2");
+        String lockPayload = "{\"locked\":true}";
+        String adminToken = getAdminToken();
+        mockMvc.perform(patch("/api/users/" + user.userId + "/lock")
+                .header("Authorization", adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(lockPayload)
+                .with(csrf()))
+            .andExpect(status().isOk());
+        mockMvc.perform(multipart("/api/auth/sign-in")
+                .param("username", "user2@otboo.com")
+                .param("password", "user2pw!")
+                .with(csrf()))
+            .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/users/" + user.userId)
+                .header("Authorization", user.token))
+            .andExpect(status().isUnauthorized());
+    }
+
+    private TestUserContext registerAndLogin(String email, String password, String name)
+        throws Exception {
+        String signupPayload = String.format(
+            "{\"email\":\"%s\",\"password\":\"%s\",\"name\":\"%s\"}", email, password, name);
+        MvcResult signupResult = mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(signupPayload)
+                .with(csrf()))
+            .andExpect(status().isCreated())
+            .andReturn();
+        String userId = extractUserId(signupResult);
+
+        MvcResult loginResult = mockMvc.perform(multipart("/api/auth/sign-in")
+                .param("username", email)
+                .param("password", password)
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+        String responseBody = loginResult.getResponse().getContentAsString();
+        String token =
+            "Bearer " + new ObjectMapper().readTree(responseBody).get("accessToken").asText();
+        return new TestUserContext(userId, token);
+    }
+
+    private static class TestUserContext {
+
+        final String userId;
+        final String token;
+
+        TestUserContext(String userId, String token) {
+            this.userId = userId;
+            this.token = token;
+        }
+    }
+
+    private String extractUserId(MvcResult result) throws Exception {
+        String response = result.getResponse().getContentAsString();
+
+        int idIdx = response.indexOf("\"id\":");
+        if (idIdx < 0) {
+            throw new IllegalStateException("userId not found in response");
+        }
+        int start = response.indexOf('"', idIdx + 5) + 1;
+        int end = response.indexOf('"', start);
+
+        return response.substring(start, end);
+    }
+
+    private String getAdminToken() throws Exception {
+        MvcResult adminLoginResult = mockMvc.perform(multipart("/api/auth/sign-in")
+                .param("username", adminEmail)
+                .param("password", adminPassword)
+                .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+        String responseBody = adminLoginResult.getResponse().getContentAsString();
+        return "Bearer " + new ObjectMapper().readTree(responseBody).get("accessToken").asText();
+    }
+}

--- a/src/integrationTest/java/com/onepiece/otboo/domain/weather/batch/config/WeatherBatchConfigTest.java
+++ b/src/integrationTest/java/com/onepiece/otboo/domain/weather/batch/config/WeatherBatchConfigTest.java
@@ -22,11 +22,18 @@ import org.springframework.batch.test.context.SpringBatchTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 @ActiveProfiles("test-integration")
 @SpringBatchTest
 @SpringBootTest
 class WeatherBatchConfigTest {
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:weatherbatchtestdb");
+    }
 
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
@@ -45,7 +52,7 @@ class WeatherBatchConfigTest {
     @BeforeEach
     void setUp() {
         weatherRepository.deleteAll();
-        ;
+
         locationRepository.deleteAll();
 
         jobLauncherTestUtils.setJob(collectWeatherJob);

--- a/src/main/java/com/onepiece/otboo/domain/auth/controller/api/AuthApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/auth/controller/api/AuthApi.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +30,11 @@ public interface AuthApi {
     })
     ResponseEntity<Void> getCsrfToken(CsrfToken csrfToken);
 
-    @Operation(summary = "로그인", description = "이메일과 비밀번호를 입력하여 로그인합니다.")
+    @Operation(
+        summary = "로그인",
+        description = "이메일과 비밀번호를 입력하여 로그인합니다.",
+        security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
@@ -60,14 +65,22 @@ public interface AuthApi {
     )
     void signIn(@ModelAttribute SignInRequest signInRequest);
 
-    @Operation(summary = "로그아웃", description = "로그아웃합니다.")
+    @Operation(
+        summary = "로그아웃",
+        description = "로그아웃합니다.",
+        security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponse(
         responseCode = "204",
         description = "로그아웃 성공"
     )
     void signOut();
 
-    @Operation(summary = "토큰 재발급", description = "쿠키(REFRESH_TOKEN)에 저장된 리프레시 토큰으로 리프레시 토큰과 엑세스 토큰을 재발급합니다.")
+    @Operation(
+        summary = "토큰 재발급",
+        description = "쿠키(REFRESH_TOKEN)에 저장된 리프레시 토큰으로 리프레시 토큰과 엑세스 토큰을 재발급합니다.",
+        security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
@@ -92,7 +105,11 @@ public interface AuthApi {
         HttpServletResponse response
     );
 
-    @Operation(summary = "임시 비밀번호 발급", description = "이메일 주소로 임시 비밀번호를 발급합니다.")
+    @Operation(
+        summary = "임시 비밀번호 발급",
+        description = "이메일 주소로 임시 비밀번호를 발급합니다.",
+        security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "비밀번호 초기화 성공"),
         @ApiResponse(

--- a/src/main/java/com/onepiece/otboo/domain/profile/entity/Profile.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/entity/Profile.java
@@ -10,6 +10,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
@@ -47,7 +48,7 @@ public class Profile extends BaseUpdatableEntity {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "location_id")
     private Location location;
 

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -81,17 +81,17 @@ public class UserController implements UserApi {
     @Override
     @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{userId}/lock")
-    public ResponseEntity<UserDto> updateUserLock(@PathVariable("userId") String userId,
+    public ResponseEntity<UserDto> updateUserLock(@PathVariable("userId") UUID userId,
         @Valid @RequestBody UserLockUpdateRequest request) {
         log.info("[UserController] 계정 잠금 상태 변경 요청 - userId: {}, locked: {}", userId,
             request.locked());
 
         UserDto result;
         if (request.locked()) {
-            result = userService.lockUser(UUID.fromString(userId));
+            result = userService.lockUser(userId);
             log.info("[UserController] 계정 잠금 성공 - userId: {}", userId);
         } else {
-            result = userService.unlockUser(UUID.fromString(userId));
+            result = userService.unlockUser(userId);
             log.info("[UserController] 계정 잠금 해제 성공 - userId: {}", userId);
         }
 

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -69,7 +69,7 @@ public class UserController implements UserApi {
     @PatchMapping("{userId}/role")
     public ResponseEntity<Void> changeRole(
         @PathVariable("userId") String userId,
-        UserRoleUpdateRequest request
+        @Valid @RequestBody UserRoleUpdateRequest request
     ) {
         log.info("[UserController] 권한 변경 요청 - userId: {}, role: {}", userId, request.role());
         userService.changeRole(UUID.fromString(userId), Role.valueOf(request.role()));

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.onepiece.otboo.domain.user.controller;
 
 import com.onepiece.otboo.domain.user.controller.api.UserApi;
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
+import com.onepiece.otboo.domain.user.dto.request.UserLockUpdateRequest;
 import com.onepiece.otboo.domain.user.dto.request.UserRoleUpdateRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
 import com.onepiece.otboo.domain.user.enums.Role;
@@ -53,5 +54,24 @@ public class UserController implements UserApi {
 
         log.info("[UserController] 권한 변경 성공 - userId: {}, role: {}", userId, request.role());
         return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @PatchMapping("/{userId}/lock")
+    public ResponseEntity<UserDto> updateUserLock(@PathVariable("userId") String userId,
+        @Valid @RequestBody UserLockUpdateRequest request) {
+        log.info("[UserController] 계정 잠금 상태 변경 요청 - userId: {}, locked: {}", userId,
+            request.locked());
+
+        UserDto result;
+        if (request.locked()) {
+            result = userService.lockUser(UUID.fromString(userId));
+            log.info("[UserController] 계정 잠금 성공 - userId: {}", userId);
+        } else {
+            result = userService.unlockUser(UUID.fromString(userId));
+            log.info("[UserController] 계정 잠금 해제 성공 - userId: {}", userId);
+        }
+
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -67,15 +67,15 @@ public class UserController implements UserApi {
     @Override
     @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("{userId}/role")
-    public ResponseEntity<Void> changeRole(
+    public ResponseEntity<UserDto> changeRole(
         @PathVariable("userId") UUID userId,
         @Valid @RequestBody UserRoleUpdateRequest request
     ) {
         log.info("[UserController] 권한 변경 요청 - userId: {}, role: {}", userId, request.role());
-        userService.changeRole(userId, Role.valueOf(request.role()));
+        UserDto result = userService.changeRole(userId, Role.valueOf(request.role()));
 
         log.info("[UserController] 권한 변경 성공 - userId: {}, role: {}", userId, request.role());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(result);
     }
 
     @Override

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,6 +45,7 @@ public class UserController implements UserApi {
     }
 
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("{userId}/role")
     public ResponseEntity<Void> changeRole(
         @PathVariable("userId") String userId,
@@ -57,6 +59,7 @@ public class UserController implements UserApi {
     }
 
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{userId}/lock")
     public ResponseEntity<UserDto> updateUserLock(@PathVariable("userId") String userId,
         @Valid @RequestBody UserLockUpdateRequest request) {

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -68,11 +68,11 @@ public class UserController implements UserApi {
     @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("{userId}/role")
     public ResponseEntity<Void> changeRole(
-        @PathVariable("userId") String userId,
+        @PathVariable("userId") UUID userId,
         @Valid @RequestBody UserRoleUpdateRequest request
     ) {
         log.info("[UserController] 권한 변경 요청 - userId: {}, role: {}", userId, request.role());
-        userService.changeRole(UUID.fromString(userId), Role.valueOf(request.role()));
+        userService.changeRole(userId, Role.valueOf(request.role()));
 
         log.info("[UserController] 권한 변경 성공 - userId: {}, role: {}", userId, request.role());
         return ResponseEntity.ok().build();

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -2,13 +2,18 @@ package com.onepiece.otboo.domain.user.controller;
 
 import com.onepiece.otboo.domain.user.controller.api.UserApi;
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
+import com.onepiece.otboo.domain.user.dto.request.UserRoleUpdateRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
+import com.onepiece.otboo.domain.user.enums.Role;
 import com.onepiece.otboo.domain.user.service.UserService;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,5 +40,18 @@ public class UserController implements UserApi {
             result.id(), result.email());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @Override
+    @PatchMapping("{userId}/role")
+    public ResponseEntity<Void> changeRole(
+        @PathVariable("userId") String userId,
+        UserRoleUpdateRequest request
+    ) {
+        log.info("[UserController] 권한 변경 요청 - userId: {}, role: {}", userId, request.role());
+        userService.changeRole(UUID.fromString(userId), Role.valueOf(request.role()));
+
+        log.info("[UserController] 권한 변경 성공 - userId: {}, role: {}", userId, request.role());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -89,7 +89,7 @@ public interface UserApi {
             )
         )
     })
-    ResponseEntity<Void> changeRole(@PathVariable("userId") String userId,
+    ResponseEntity<Void> changeRole(@PathVariable("userId") UUID userId,
         @Valid @RequestBody UserRoleUpdateRequest request);
 
     @Operation(

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -112,6 +113,6 @@ public interface UserApi {
             )
         )
     })
-    ResponseEntity<UserDto> updateUserLock(@PathVariable("userId") String userId,
+    ResponseEntity<UserDto> updateUserLock(@PathVariable("userId") UUID userId,
         @Valid @RequestBody UserLockUpdateRequest request);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -1,6 +1,7 @@
 package com.onepiece.otboo.domain.user.controller.api;
 
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
+import com.onepiece.otboo.domain.user.dto.request.UserLockUpdateRequest;
 import com.onepiece.otboo.domain.user.dto.request.UserRoleUpdateRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
 import com.onepiece.otboo.global.dto.response.ErrorResponse;
@@ -61,4 +62,28 @@ public interface UserApi {
     })
     ResponseEntity<Void> changeRole(@PathVariable("id") String userId,
         @RequestBody UserRoleUpdateRequest request);
+
+    @Operation(
+        summary = "계정 잠금 상태 변경",
+        description = "[어드민 기능] 계정 잠금 상태를 변경합니다.",
+        security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200", description = "계정 잠금 상태 변경 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = UserDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404", description = "계정 잠금 상태 변경 실패(사용자 없음)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<UserDto> updateUserLock(@PathVariable("userId") String userId,
+        @Valid @RequestBody UserLockUpdateRequest request);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -68,7 +68,8 @@ public interface UserApi {
             )
         )
     })
-    ResponseEntity<CursorPageResponseDto<UserDto>> getUsers(@Valid @ModelAttribute UserGetRequest request);
+    ResponseEntity<CursorPageResponseDto<UserDto>> getUsers(
+        @Valid @ModelAttribute UserGetRequest request);
 
     @Operation(
         summary = "권한 수정",
@@ -87,8 +88,8 @@ public interface UserApi {
             )
         )
     })
-    ResponseEntity<Void> changeRole(@PathVariable("id") String userId,
-        @RequestBody UserRoleUpdateRequest request);
+    ResponseEntity<Void> changeRole(@PathVariable("userId") String userId,
+        @Valid @RequestBody UserRoleUpdateRequest request);
 
     @Operation(
         summary = "계정 잠금 상태 변경",

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -89,7 +89,7 @@ public interface UserApi {
             )
         )
     })
-    ResponseEntity<Void> changeRole(@PathVariable("userId") UUID userId,
+    ResponseEntity<UserDto> changeRole(@PathVariable("userId") UUID userId,
         @Valid @RequestBody UserRoleUpdateRequest request);
 
     @Operation(

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -1,6 +1,7 @@
 package com.onepiece.otboo.domain.user.controller.api;
 
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
+import com.onepiece.otboo.domain.user.dto.request.UserRoleUpdateRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
 import com.onepiece.otboo.global.dto.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "프로필 관리", description = "프로필 관련 API")
@@ -39,4 +41,24 @@ public interface UserApi {
         )
     })
     ResponseEntity<UserDto> create(@Valid @RequestBody UserCreateRequest userCreateRequest);
+
+    @Operation(
+        summary = "권한 수정",
+        description = "권한 수정 API",
+        security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200", description = "권한 변경 성공"
+        ),
+        @ApiResponse(
+            responseCode = "404", description = "권한 변경 실패(사용자 없음)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<Void> changeRole(@PathVariable("id") String userId,
+        @RequestBody UserRoleUpdateRequest request);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserLockUpdateRequest.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserLockUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.onepiece.otboo.domain.user.dto.request;
+
+public record UserLockUpdateRequest(
+    Boolean locked
+) {
+
+}

--- a/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserLockUpdateRequest.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserLockUpdateRequest.java
@@ -1,7 +1,9 @@
 package com.onepiece.otboo.domain.user.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 public record UserLockUpdateRequest(
-    Boolean locked
+    @NotNull Boolean locked
 ) {
 
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserRoleUpdateRequest.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserRoleUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.onepiece.otboo.domain.user.dto.request;
+
+public record UserRoleUpdateRequest(String role) {
+
+}

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserService.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserService.java
@@ -2,8 +2,12 @@ package com.onepiece.otboo.domain.user.service;
 
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
+import com.onepiece.otboo.domain.user.enums.Role;
+import java.util.UUID;
 
 public interface UserService {
 
     UserDto create(UserCreateRequest userCreateRequest);
+
+    void changeRole(UUID userId, Role role);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserService.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserService.java
@@ -13,7 +13,7 @@ public interface UserService {
 
     CursorPageResponseDto<UserDto> getUsers(UserGetRequest userGetRequest);
 
-    void changeRole(UUID userId, Role role);
+    UserDto changeRole(UUID userId, Role role);
 
     UserDto lockUser(UUID userId);
 

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserService.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserService.java
@@ -10,4 +10,8 @@ public interface UserService {
     UserDto create(UserCreateRequest userCreateRequest);
 
     void changeRole(UUID userId, Role role);
+
+    UserDto lockUser(UUID userId);
+
+    UserDto unlockUser(UUID userId);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
@@ -12,6 +12,8 @@ import com.onepiece.otboo.domain.user.exception.UserNotFoundException;
 import com.onepiece.otboo.domain.user.mapper.UserMapper;
 import com.onepiece.otboo.domain.user.repository.UserRepository;
 import com.onepiece.otboo.global.exception.ErrorCode;
+import com.onepiece.otboo.infra.security.jwt.JwtRegistry;
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,7 @@ public class UserServiceImpl implements UserService {
     private final ProfileRepository profileRepository;
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
+    private final JwtRegistry jwtRegistry;
 
     @Override
     @Transactional
@@ -77,6 +80,41 @@ public class UserServiceImpl implements UserService {
             .orElseThrow(() -> UserNotFoundException.byId(userId));
         user.updateRole(role);
         userRepository.save(user);
-        log.info("[UserService] 사용자 권한 변경 - userId: {}, role: {}", userId, role);
+
+        jwtRegistry.invalidateAllTokens(userId, Instant.now());
+
+        log.info("[UserService] 사용자 권한 변경 - userId: {}, role: {}, 토큰 무효화 완료", userId, role);
+    }
+
+    @Override
+    @Transactional
+    public UserDto lockUser(UUID userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> UserNotFoundException.byId(userId));
+        user.updateLocked(true);
+        userRepository.save(user);
+
+        jwtRegistry.invalidateAllTokens(userId, Instant.now());
+
+        log.info("[UserService] 사용자 계정 잠금 완료 - userId: {}, 토큰 무효화 완료", userId);
+
+        Profile profile = profileRepository.findByUserId(userId)
+            .orElse(null);
+        return userMapper.toDto(user, profile);
+    }
+
+    @Override
+    @Transactional
+    public UserDto unlockUser(UUID userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> UserNotFoundException.byId(userId));
+        user.updateLocked(false);
+        userRepository.save(user);
+
+        log.info("[UserService] 사용자 계정 잠금 해제 완료 - userId: {}", userId);
+
+        Profile profile = profileRepository.findByUserId(userId)
+            .orElse(null);
+        return userMapper.toDto(user, profile);
     }
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
@@ -119,7 +119,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void changeRole(UUID userId, Role role) {
+    public UserDto changeRole(UUID userId, Role role) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> UserNotFoundException.byId(userId));
         user.updateRole(role);
@@ -128,6 +128,8 @@ public class UserServiceImpl implements UserService {
         jwtRegistry.invalidateAllTokens(userId, Instant.now());
 
         log.info("[UserService] 사용자 권한 변경 - userId: {}, role: {}, 토큰 무효화 완료", userId, role);
+
+        return userMapper.toDto(user, profileRepository.findByUserId(userId).orElse(null));
     }
 
     @Override

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
@@ -8,10 +8,12 @@ import com.onepiece.otboo.domain.user.entity.User;
 import com.onepiece.otboo.domain.user.enums.Provider;
 import com.onepiece.otboo.domain.user.enums.Role;
 import com.onepiece.otboo.domain.user.exception.DuplicateEmailException;
+import com.onepiece.otboo.domain.user.exception.UserNotFoundException;
 import com.onepiece.otboo.domain.user.mapper.UserMapper;
 import com.onepiece.otboo.domain.user.repository.UserRepository;
 import com.onepiece.otboo.global.exception.ErrorCode;
 import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -66,5 +68,15 @@ public class UserServiceImpl implements UserService {
             .build();
 
         return profileRepository.save(profile);
+    }
+
+    @Override
+    @Transactional
+    public void changeRole(UUID userId, Role role) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> UserNotFoundException.byId(userId));
+        user.updateRole(role);
+        userRepository.save(user);
+        log.info("[UserService] 사용자 권한 변경 - userId: {}, role: {}", userId, role);
     }
 }

--- a/src/main/java/com/onepiece/otboo/infra/security/auth/CustomAuthenticationProvider.java
+++ b/src/main/java/com/onepiece/otboo/infra/security/auth/CustomAuthenticationProvider.java
@@ -7,6 +7,7 @@ import com.onepiece.otboo.infra.security.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -28,6 +29,9 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
         String password = authentication.getCredentials().toString();
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> new BadCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."));
+        if (user.isLocked()) {
+            throw new LockedException("계정이 잠겨 있습니다.");
+        }
         if (passwordEncoder.matches(password, user.getPassword())) {
             CustomUserDetails userDetails = customUserDetailsMapper.toCustomUserDetails(user);
             return new UsernamePasswordAuthenticationToken(userDetails, password,

--- a/src/main/java/com/onepiece/otboo/infra/seeder/AdminAccountInitializer.java
+++ b/src/main/java/com/onepiece/otboo/infra/seeder/AdminAccountInitializer.java
@@ -1,0 +1,50 @@
+package com.onepiece.otboo.infra.seeder;
+
+import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.domain.user.enums.Provider;
+import com.onepiece.otboo.domain.user.enums.Role;
+import com.onepiece.otboo.domain.user.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdminAccountInitializer {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${otboo.admin.email}")
+    protected String adminEmail;
+    @Value("${otboo.admin.password}")
+    protected String adminPassword;
+
+    @PostConstruct
+    public void initializeAdminAccount() {
+        Optional<User> adminOpt = userRepository.findByEmail(adminEmail);
+        User admin;
+        if (adminOpt.isEmpty()) {
+            admin = User.builder()
+                .provider(Provider.LOCAL)
+                .email(adminEmail)
+                .password(passwordEncoder.encode(adminPassword))
+                .role(Role.ADMIN)
+                .locked(false)
+                .temporaryPassword(null)
+                .temporaryPasswordExpirationTime(null)
+                .build();
+        } else {
+            admin = adminOpt.get();
+            admin.updatePassword(passwordEncoder.encode(adminPassword));
+            admin.updateRole(Role.ADMIN);
+            admin.updateLocked(false);
+        }
+        userRepository.save(admin);
+    }
+}

--- a/src/main/java/com/onepiece/otboo/infra/seeder/LocationTableSeeder.java
+++ b/src/main/java/com/onepiece/otboo/infra/seeder/LocationTableSeeder.java
@@ -38,7 +38,7 @@ public class LocationTableSeeder implements DataSeeder {
             String city = cities[randInt(0, cities.length - 1)];
             String district = districts[randInt(0, districts.length - 1)];
             String neighborhood = neighborhoods[randInt(0, neighborhoods.length - 1)];
-            String locationName = city + " " + district + " " + neighborhood;
+            String locationName = city + "," + district + "," + neighborhood;
             Location location = Location.builder()
                 .latitude(lat)
                 .longitude(lon)

--- a/src/main/java/com/onepiece/otboo/infra/seeder/UserProfileTableSeeder.java
+++ b/src/main/java/com/onepiece/otboo/infra/seeder/UserProfileTableSeeder.java
@@ -39,7 +39,8 @@ public class UserProfileTableSeeder implements DataSeeder {
         int count = 0;
         for (int i = 0; i < users.size(); i++) {
             User user = users.get(i);
-            Location location = locations.isEmpty() ? null : locations.get(i % locations.size());
+            Location location =
+                locations.isEmpty() ? null : locations.get(randInt(0, locations.size() - 1));
             String nickname = "user" + (i + 1);
             Gender gender = switch (i % 3) {
                 case 0 -> Gender.MALE;

--- a/src/main/java/com/onepiece/otboo/infra/seeder/UserTableSeeder.java
+++ b/src/main/java/com/onepiece/otboo/infra/seeder/UserTableSeeder.java
@@ -21,7 +21,7 @@ public class UserTableSeeder implements DataSeeder {
 
     @Override
     public void seed() {
-        if (userRepository.count() > 0) {
+        if (userRepository.count() > 1) {
             return;
         }
         int count = 0;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,6 +69,9 @@ otboo:
         enabled: true
         username: ${SWAGGER_BASIC_USERNAME}
         password: ${SWAGGER_BASIC_PASSWORD}
+  admin:
+    email: ${ADMIN_EMAIL}
+    password: ${ADMIN_PASSWORD}
 
 api:
   kakao:

--- a/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
@@ -251,7 +251,16 @@ class UserControllerTest {
         String userId = String.valueOf(UUID.randomUUID());
         String role = "ADMIN";
         UserRoleUpdateRequest req = new UserRoleUpdateRequest(role);
-        Mockito.doNothing().when(userService).changeRole(any(UUID.class), any());
+        UserDto userDto = UserDto.builder()
+            .id(UUID.fromString(userId))
+            .email("test@test.com")
+            .name("test")
+            .role(Role.ADMIN)
+            .locked(false)
+            .build();
+
+        Mockito.doReturn(userDto).when(userService)
+            .changeRole(any(UUID.class), any());
 
         ResultActions result = mockMvc.perform(patch("/api/users/" + userId + "/role")
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/onepiece/otboo/infra/seeder/AdminAccountInitializerTest.java
+++ b/src/test/java/com/onepiece/otboo/infra/seeder/AdminAccountInitializerTest.java
@@ -1,0 +1,60 @@
+package com.onepiece.otboo.infra.seeder;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.domain.user.enums.Provider;
+import com.onepiece.otboo.domain.user.enums.Role;
+import com.onepiece.otboo.domain.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+class AdminAccountInitializerTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @InjectMocks
+    private AdminAccountInitializer adminAccountInitializer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        adminAccountInitializer.adminEmail = "admin@example.com";
+        adminAccountInitializer.adminPassword = "admin1234";
+    }
+
+    @Test
+    void 어드민_계정_없으면_생성() {
+        when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(any())).thenReturn("encoded");
+        adminAccountInitializer.initializeAdminAccount();
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    void 어드민_계정_있으면_초기화() {
+        User admin = User.builder()
+            .provider(Provider.LOCAL)
+            .email("admin@example.com")
+            .password("old")
+            .role(Role.USER)
+            .locked(true)
+            .build();
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(admin));
+        when(passwordEncoder.encode(any())).thenReturn("encoded");
+        adminAccountInitializer.initializeAdminAccount();
+        verify(userRepository, times(1)).save(admin);
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요

- **초기화**: 서버 시작 시 어드민 계정을 자동으로 초기화합니다.
- **권한 관리**: 사용자의 권한을 `ADMIN` 또는 `USER`로 변경할 수 있습니다. 권한 변경 시 해당 사용자는 **자동으로 로그아웃**됩니다.
- **계정 잠금**: 사용자 계정을 잠글 수 있으며, 잠긴 계정은 로그인할 수 없습니다. 잠긴 계정은 **자동으로 로그아웃**됩니다.

## ✅ 완료한 작업

- **초기화**: 서버 시작 시 어드민 계정을 자동으로 초기화합니다.
- **권한 관리**: 사용자의 권한을 `ADMIN` 또는 `USER`로 변경할 수 있습니다. 권한 변경 시 해당 사용자는 **자동으로 로그아웃**됩니다.
- **계정 잠금**: 사용자 계정을 잠글 수 있으며, 잠긴 계정은 로그인할 수 없습니다. 잠긴 계정은 **자동으로 로그아웃**됩니다.

## 🧪 테스트 결과

- [x] 서버 시작 시 어드민 계정을 자동으로 초기화합니다.
- [x] 사용자의 권한을 `ADMIN` 또는 `USER`로 변경할 수 있습니다. 권한 변경 시 해당 사용자는 **자동으로 로그아웃됩니다.
- [x] 사용자 계정을 잠글 수 있으며, 잠긴 계정은 로그인할 수 없습니다. 잠긴 계정은 **자동으로 로그아웃**됩니다.
- [x] 어드민 계정 초기화 및 권한 변경, 잠금 관리 통합 테스트

## ⚠️ 기타 참고 사항

- 간헐적으로 실패하는 통합 테스트에 대한 일부 수정이 포함되어 있습니다.

---

## Related Issue

Closes #69 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 관리자용 사용자 역할 변경·계정 잠금/해제 API 및 서버 시작시 관리자 계정 자동 초기화 추가.
- Bug Fixes
  - 잠긴 계정 로그인 즉시 거부 처리 및 역할 변경·계정 잠금 시 JWT 무효화로 즉시 로그아웃 보장.
- Documentation
  - 인증 요구사항(SecurityRequirement)이 API 명세에 반영되어 헤더 요구사항 명시.
- Tests
  - 관리자 통합·단위 테스트, 사용자 잠금/역할 관련 테스트 및 배치 테스트 설정(H2) 추가.
- Chores
  - 시드 데이터 일부 표기·배치 변경 및 CI에 관리자 자격환경변수 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->