### PR TITLE
[Feature] 피드 수정 기능

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/controller/FeedController.java
@@ -2,14 +2,24 @@ package com.onepiece.otboo.domain.feed.controller;
 
 import com.onepiece.otboo.domain.feed.controller.api.FeedApi;
 import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
+import com.onepiece.otboo.domain.feed.dto.request.FeedUpdateRequest;
 import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
 import com.onepiece.otboo.domain.feed.service.FeedService;
+import com.onepiece.otboo.global.exception.ErrorCode;
+import com.onepiece.otboo.global.exception.GlobalException;
+import com.onepiece.otboo.infra.security.userdetails.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 import java.util.UUID;
@@ -34,5 +44,33 @@ public class FeedController implements FeedApi {
 
         feedService.delete(feedId, requesterId);
         return ResponseEntity.noContent().build(); // 204
+    }
+
+    @PatchMapping("/{feedId}")
+    @Override
+    public ResponseEntity<FeedResponse> updateFeed(@PathVariable UUID feedId,
+                                                   @Valid @RequestBody FeedUpdateRequest req) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new AccessDeniedException("Unauthenticated");
+        }
+
+        UUID requesterId = resolveRequesterId(auth);
+
+        FeedResponse res = feedService.update(feedId, requesterId, req);
+        return ResponseEntity.ok(res);
+    }
+
+    private UUID resolveRequesterId(Authentication auth) {
+        Object principal = auth.getPrincipal();
+
+        if (principal instanceof CustomUserDetails cud) {
+            return cud.getUserId();
+        }
+        try {
+            return UUID.fromString(auth.getName());
+        } catch (IllegalArgumentException e) {
+            throw new GlobalException(ErrorCode.FEED_FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/controller/api/FeedApi.java
@@ -1,6 +1,7 @@
 package com.onepiece.otboo.domain.feed.controller.api;
 
 import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
+import com.onepiece.otboo.domain.feed.dto.request.FeedUpdateRequest;
 import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
 import com.onepiece.otboo.global.dto.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -83,22 +85,26 @@ public interface FeedApi {
     )
     @SecurityRequirement(name = "bearerAuth")
     @ApiResponses({
-        @ApiResponse(responseCode = "204",
+        @ApiResponse(
+            responseCode = "204",
             description = "피드 삭제 성공"
         ),
-        @ApiResponse(responseCode = "401",
+        @ApiResponse(
+            responseCode = "401",
             description = "인증 실패",
             content = @Content(
                 schema = @Schema(implementation = ErrorResponse.class
                 ))
         ),
-        @ApiResponse(responseCode = "403",
+        @ApiResponse(
+            responseCode = "403",
             description = "권한 부족/소유권 불일치",
             content = @Content(
                 schema = @Schema(implementation = ErrorResponse.class
                 ))
         ),
-        @ApiResponse(responseCode = "404",
+        @ApiResponse(
+            responseCode = "404",
             description = "존재하지 않는 피드",
             content = @Content(
                 schema = @Schema(implementation = ErrorResponse.class
@@ -107,4 +113,13 @@ public interface FeedApi {
     })
     @DeleteMapping(value = "/{feedId}")
     ResponseEntity<Void> deleteFeed(@PathVariable UUID feedId);
+
+    @Operation(summary = "피드 수정",
+        description = "작성자 본인이 피드 내용을 수정합니다."
+    )
+    @PatchMapping(value = "/{feedId}", consumes = "application/json", produces = "application/json")
+    ResponseEntity<FeedResponse> updateFeed(@PathVariable UUID feedId, @Valid @RequestBody FeedUpdateRequest req);
+
 }
+
+

--- a/src/main/java/com/onepiece/otboo/domain/feed/dto/request/FeedUpdateRequest.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/dto/request/FeedUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.onepiece.otboo.domain.feed.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record FeedUpdateRequest(
+    @Size(max = 1000) String content
+) {}
+

--- a/src/main/java/com/onepiece/otboo/domain/feed/entity/Feed.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/entity/Feed.java
@@ -49,4 +49,8 @@ public class Feed extends BaseUpdatableEntity {
     public void updateContent(String content) {
         this.content = content;
     }
+
+    public void updateWeatherId(UUID weatherId) {
+        this.weatherId = weatherId;
+    }
 }

--- a/src/main/java/com/onepiece/otboo/domain/feed/service/FeedService.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/service/FeedService.java
@@ -1,6 +1,7 @@
 package com.onepiece.otboo.domain.feed.service;
 
 import com.onepiece.otboo.domain.feed.dto.request.FeedCreateRequest;
+import com.onepiece.otboo.domain.feed.dto.request.FeedUpdateRequest;
 import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
 import com.onepiece.otboo.domain.feed.entity.Feed;
 import com.onepiece.otboo.domain.feed.entity.FeedClothes;
@@ -81,4 +82,15 @@ public class FeedService {
 
         feedRepository.delete(feed); // or deleteById(feedId)
     }
+
+    @Transactional
+    public FeedResponse update(UUID feedId, UUID requesterId, FeedUpdateRequest req) {
+        Feed feed = feedRepository.findById(feedId)
+            .orElseThrow(() -> new GlobalException(ErrorCode.FEED_NOT_FOUND));
+        if (!feed.getAuthorId().equals(requesterId)) throw new GlobalException(ErrorCode.FEED_FORBIDDEN);
+
+        feed.updateContent(req.content());
+        return feedMapper.toResponse(feed);
+    }
+
 }

--- a/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "피드 확인 실패", "피드를 찾을 수 없습니다."),
     FEED_FORBIDDEN(HttpStatus.FORBIDDEN, "피드 권한 없음", "해당 피드에 접근/수정/삭제 권한이 없습니다."),
     FEED_GONE(HttpStatus.GONE, "삭제된 피드", "이미 삭제된 피드입니다."),
+    FEED_CLOTHES_REQUIRED(HttpStatus.BAD_REQUEST, "의상 목록 누락", "피드에는 최소 1개 이상의 의상이 필요합니다."),
 
     // LOCATION
     INVALID_COORDINATE(HttpStatus.BAD_REQUEST, "유효하지 않은 좌표 값입니다.", "위도와 경도를 확인해주세요."),

--- a/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerUpdateTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/controller/FeedControllerUpdateTest.java
@@ -1,0 +1,172 @@
+package com.onepiece.otboo.domain.feed.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onepiece.otboo.domain.feed.dto.request.FeedUpdateRequest;
+import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
+import com.onepiece.otboo.domain.feed.service.FeedService;
+import com.onepiece.otboo.global.exception.ErrorCode;
+import com.onepiece.otboo.global.exception.GlobalException;
+import com.onepiece.otboo.infra.security.userdetails.CustomUserDetails;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = FeedController.class)
+class FeedControllerUpdateTest {
+
+    private static final String BASE_URL = "/api/feeds";
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean
+    FeedService feedService;
+
+    @Test
+    @WithMockUser(username = "11111111-1111-1111-1111-111111111111")
+    void 피드_수정_성공시_200응답_username_UUID() throws Exception {
+        UUID feedId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        UUID requesterId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+        FeedResponse mocked = Mockito.mock(FeedResponse.class);
+        when(feedService.update(eq(feedId), eq(requesterId), any(FeedUpdateRequest.class)))
+            .thenReturn(mocked);
+
+        var body = new FeedUpdateRequest("updated content");
+        mockMvc.perform(
+            patch(BASE_URL + "/{id}", feedId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+        ).andExpect(status().isOk());
+
+        verify(feedService, times(1)).update(eq(feedId), eq(requesterId), any(FeedUpdateRequest.class));
+        verifyNoMoreInteractions(feedService);
+    }
+
+    @Test
+    void 피드_수정_성공시_200응답_principal_CustomUserDetails() throws Exception {
+        UUID feedId = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        UUID requesterId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+        CustomUserDetails cud = Mockito.mock(CustomUserDetails.class);
+        when(cud.getUserId()).thenReturn(requesterId);
+        var token = new TestingAuthenticationToken(cud, null);
+        token.setAuthenticated(true);
+
+        FeedResponse mocked = Mockito.mock(FeedResponse.class);
+        when(feedService.update(eq(feedId), eq(requesterId), any(FeedUpdateRequest.class)))
+            .thenReturn(mocked);
+
+        var body = new FeedUpdateRequest("server principal path");
+        mockMvc.perform(
+            patch(BASE_URL + "/{id}", feedId)
+                .with(csrf())
+                .with(authentication(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+        ).andExpect(status().isOk());
+
+        verify(feedService, times(1)).update(eq(feedId), eq(requesterId), any(FeedUpdateRequest.class));
+        verifyNoMoreInteractions(feedService);
+    }
+
+    @Test
+    @WithMockUser(username = "not-a-uuid")
+    void 피드_수정_잘못된_Principal_UUID_형식시_403응답() throws Exception {
+        UUID feedId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+        var body = new FeedUpdateRequest("content");
+        mockMvc.perform(
+            patch(BASE_URL + "/{id}", feedId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+        ).andExpect(status().isForbidden());
+
+        verifyNoInteractions(feedService);
+    }
+
+    @Test
+    @WithMockUser(username = "33333333-3333-3333-3333-333333333333")
+    void 피드_수정_유효성검증_실패시_400응답() throws Exception {
+        UUID feedId = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+
+        String tooLong = "x".repeat(1001);
+        var body = new FeedUpdateRequest(tooLong);
+
+        mockMvc.perform(
+            patch(BASE_URL + "/{id}", feedId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+        ).andExpect(status().isBadRequest());
+
+        verifyNoInteractions(feedService);
+    }
+
+    @Test
+    @WithMockUser(username = "44444444-4444-4444-4444-444444444444")
+    void 피드_수정_FEED_NOT_FOUND_시_404응답() throws Exception {
+        UUID feedId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+        UUID requesterId = UUID.fromString("44444444-4444-4444-4444-444444444444");
+
+        doThrow(new GlobalException(ErrorCode.FEED_NOT_FOUND))
+            .when(feedService).update(eq(feedId), eq(requesterId), any(FeedUpdateRequest.class));
+
+        var body = new FeedUpdateRequest("content");
+        mockMvc.perform(
+            patch(BASE_URL + "/{id}", feedId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+        ).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "55555555-5555-5555-5555-555555555555")
+    void 피드_수정_FEED_FORBIDDEN_시_403응답() throws Exception {
+        UUID feedId = UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff");
+        UUID requesterId = UUID.fromString("55555555-5555-5555-5555-555555555555");
+
+        doThrow(new GlobalException(ErrorCode.FEED_FORBIDDEN))
+            .when(feedService).update(eq(feedId), eq(requesterId), any(FeedUpdateRequest.class));
+
+        var body = new FeedUpdateRequest("content");
+        mockMvc.perform(
+            patch(BASE_URL + "/{id}", feedId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+        ).andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 피드_수정_미인증사용자_요청시_401응답() throws Exception {
+        UUID feedId = UUID.randomUUID();
+        var body = new FeedUpdateRequest("content");
+
+        mockMvc.perform(
+            patch(BASE_URL + "/{id}", feedId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+        ).andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/onepiece/otboo/domain/feed/service/FeedServiceUpdateTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/service/FeedServiceUpdateTest.java
@@ -1,0 +1,101 @@
+package com.onepiece.otboo.domain.feed.service;
+
+import com.onepiece.otboo.domain.feed.dto.request.FeedUpdateRequest;
+import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
+import com.onepiece.otboo.domain.feed.entity.Feed;
+import com.onepiece.otboo.domain.feed.mapper.FeedMapper;
+import com.onepiece.otboo.domain.feed.repository.FeedRepository;
+import com.onepiece.otboo.domain.user.repository.UserRepository;
+import com.onepiece.otboo.domain.weather.repository.WeatherRepository;
+import com.onepiece.otboo.global.exception.ErrorCode;
+import com.onepiece.otboo.global.exception.GlobalException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedServiceUpdateTest {
+
+    @Mock FeedRepository feedRepository;
+    @Mock UserRepository userRepository;         // 생성자 주입 시그니처 맞춤용
+    @Mock WeatherRepository weatherRepository;   // 생성자 주입 시그니처 맞춤용
+    @Mock FeedMapper feedMapper;
+
+    @InjectMocks
+    FeedService feedService;
+
+    @Test
+    @DisplayName("피드_수정_성공시_내용이_업데이트되고_Response_반환")
+    void 피드_수정_성공시_내용이_업데이트되고_Response_반환() {
+        UUID feedId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        UUID requesterId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+        Feed feed = mock(Feed.class);
+        when(feed.getAuthorId()).thenReturn(requesterId);
+        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
+
+        FeedResponse response = mock(FeedResponse.class);
+        when(feedMapper.toResponse(feed)).thenReturn(response);
+
+        var req = new FeedUpdateRequest("new content");
+        FeedResponse result = feedService.update(feedId, requesterId, req);
+
+        assertNotNull(result);
+        assertEquals(response, result);
+
+        InOrder inOrder = inOrder(feedRepository, feed, feedMapper);
+        inOrder.verify(feedRepository).findById(feedId);
+        inOrder.verify(feed).getAuthorId();
+        inOrder.verify(feed).updateContent("new content");
+        inOrder.verify(feedMapper).toResponse(feed);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("피드_수정_대상없음_FEED_NOT_FOUND")
+    void 피드_수정_대상없음_FEED_NOT_FOUND() {
+        UUID feedId = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        UUID requesterId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+        when(feedRepository.findById(feedId)).thenReturn(Optional.empty());
+
+        GlobalException ex = assertThrows(GlobalException.class,
+            () -> feedService.update(feedId, requesterId, new FeedUpdateRequest("x")));
+        assertEquals(ErrorCode.FEED_NOT_FOUND, ex.getErrorCode());
+
+        verify(feedRepository, times(1)).findById(feedId);
+        verifyNoMoreInteractions(feedRepository);
+        verifyNoInteractions(feedMapper);
+    }
+
+    @Test
+    @DisplayName("피드_수정_작성자불일치_FEED_FORBIDDEN")
+    void 피드_수정_작성자불일치_FEED_FORBIDDEN() {
+        UUID feedId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        UUID requesterId = UUID.fromString("33333333-3333-3333-3333-333333333333");
+
+        UUID authorId = UUID.fromString("44444444-4444-4444-4444-444444444444");
+        Feed feed = mock(Feed.class);
+        when(feed.getAuthorId()).thenReturn(authorId);
+        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
+
+        GlobalException ex = assertThrows(GlobalException.class,
+            () -> feedService.update(feedId, requesterId, new FeedUpdateRequest("x")));
+        assertEquals(ErrorCode.FEED_FORBIDDEN, ex.getErrorCode());
+
+        verify(feedRepository, times(1)).findById(feedId);
+        verify(feed, times(1)).getAuthorId();
+        verifyNoMoreInteractions(feedRepository, feed, feedMapper);
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요

* 피드 내용 수정 기능 구현

## ✅ 완료한 작업

* `PATCH /api/feeds/{feedId}` 엔드포인트 추가
* `SecurityContextHolder` 기반 요청자 ID 추출 로직 적용
* 작성자 본인만 수정 가능하도록 권한 검증 로직 추가

## 🧪 테스트 결과

* 로컬 환경에서 정상 동작 확인 (성공/권한 없음/존재하지 않는 피드/유효성 검증 실패 케이스)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 피드 수정 API(PATCH /feeds/{feedId}) 추가: 내용 업데이트 및 권한 검증, 업데이트된 피드 반환
  - 피드 내용 길이 제한(최대 1000자) 검증 도입
  - 신규 오류 코드 추가: 의상 목록 누락 시 요청 거부
- Documentation
  - Swagger/OpenAPI에 피드 수정 엔드포인트와 응답/오류 스펙 반영
- Tests
  - 컨트롤러·서비스 테스트 추가: 성공, 미인증, 권한 거부, 유효성 실패, 미존재 케이스 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->