### PR TITLE
[Feature] 사용자 권한 수정 기능 추가

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/profile/exception/ProfileException.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/exception/ProfileException.java
@@ -1,0 +1,16 @@
+package com.onepiece.otboo.domain.profile.exception;
+
+import com.onepiece.otboo.global.exception.ErrorCode;
+import com.onepiece.otboo.global.exception.GlobalException;
+import java.util.Map;
+
+public class ProfileException extends GlobalException {
+
+    public ProfileException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ProfileException(ErrorCode errorCode, Map<String, Object> details) {
+        super(errorCode, details);
+    }
+}

--- a/src/main/java/com/onepiece/otboo/domain/profile/exception/ProfileNotFoundException.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/exception/ProfileNotFoundException.java
@@ -1,0 +1,12 @@
+package com.onepiece.otboo.domain.profile.exception;
+
+import com.onepiece.otboo.global.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class ProfileNotFoundException extends ProfileException {
+
+    public ProfileNotFoundException(UUID userId) {
+        super(ErrorCode.PROFILE_NOT_FOUND, Map.of("userId", userId));
+    }
+}

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -3,17 +3,22 @@ package com.onepiece.otboo.domain.user.controller;
 import com.onepiece.otboo.domain.user.controller.api.UserApi;
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.request.UserGetRequest;
+import com.onepiece.otboo.domain.user.dto.request.UserRoleUpdateRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
+import com.onepiece.otboo.domain.user.enums.Role;
 import com.onepiece.otboo.domain.user.service.UserService;
 import com.onepiece.otboo.global.dto.response.CursorPageResponseDto;
 import jakarta.validation.Valid;
 import java.util.Locale;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,6 +59,22 @@ public class UserController implements UserApi {
 
         log.info("[UserController] 계정 목록 조회 성공 - {}개의 데이터, 다음 페이지 존재 여부: {}",
             result.data().size(), result.hasNext());
+
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    @Override
+    @PatchMapping("/{userId}/role")
+    public ResponseEntity<UserDto> updateUserRole(
+        @PathVariable UUID userId,
+        @Valid @RequestBody UserRoleUpdateRequest request) {
+
+        Role role = request.role();
+        log.info("[UserController] 권한 수정 요청 - id: {} role: {}", userId, role);
+
+        UserDto result = userService.updateUserRole(userId, role);
+
+        log.info("UserController] 권한 수정 성공 - id: {}", result.id());
 
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -68,7 +68,8 @@ public interface UserApi {
             )
         )
     })
-    ResponseEntity<CursorPageResponseDto<UserDto>> getUsers(@Valid @ModelAttribute UserGetRequest request);
+    ResponseEntity<CursorPageResponseDto<UserDto>> getUsers(
+        @Valid @ModelAttribute UserGetRequest request);
 
     @Operation(
         summary = "권한 수정"

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -2,6 +2,7 @@ package com.onepiece.otboo.domain.user.controller.api;
 
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.request.UserGetRequest;
+import com.onepiece.otboo.domain.user.dto.request.UserRoleUpdateRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
 import com.onepiece.otboo.global.dto.response.CursorPageResponseDto;
 import com.onepiece.otboo.global.dto.response.ErrorResponse;
@@ -14,8 +15,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "프로필 관리", description = "프로필 관련 API")
@@ -66,4 +69,29 @@ public interface UserApi {
         )
     })
     ResponseEntity<CursorPageResponseDto<UserDto>> getUsers(@Valid @ModelAttribute UserGetRequest request);
+
+    @Operation(
+        summary = "권한 수정"
+        , description = "권한 수정 API"
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200", description = "권한 수정 성공",
+            content = @Content(
+                mediaType = "*/*",
+                array = @ArraySchema(schema = @Schema(implementation = UserDto.class))
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404", description = "권한 수정 실패(사용자 없음)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<UserDto> updateUserRole(
+        @PathVariable UUID userId,
+        @Valid @RequestBody UserRoleUpdateRequest request);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserRoleUpdateRequest.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserRoleUpdateRequest.java
@@ -1,8 +1,10 @@
 package com.onepiece.otboo.domain.user.dto.request;
 
 import com.onepiece.otboo.domain.user.enums.Role;
+import jakarta.validation.constraints.NotNull;
 
 public record UserRoleUpdateRequest(
+    @NotNull(message = "role은 필수 값입니다.")
     Role role
 ) {
 

--- a/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserRoleUpdateRequest.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/dto/request/UserRoleUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.onepiece.otboo.domain.user.dto.request;
+
+import com.onepiece.otboo.domain.user.enums.Role;
+
+public record UserRoleUpdateRequest(
+    Role role
+) {
+
+}

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserService.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserService.java
@@ -3,11 +3,15 @@ package com.onepiece.otboo.domain.user.service;
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.request.UserGetRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
+import com.onepiece.otboo.domain.user.enums.Role;
 import com.onepiece.otboo.global.dto.response.CursorPageResponseDto;
+import java.util.UUID;
 
 public interface UserService {
 
     UserDto create(UserCreateRequest userCreateRequest);
 
     CursorPageResponseDto<UserDto> getUsers(UserGetRequest userGetRequest);
+
+    UserDto updateUserRole(UUID userId, Role role);
 }

--- a/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.onepiece.otboo.domain.user.service;
 
 import com.onepiece.otboo.domain.profile.entity.Profile;
+import com.onepiece.otboo.domain.profile.exception.ProfileNotFoundException;
 import com.onepiece.otboo.domain.profile.repository.ProfileRepository;
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.request.UserGetRequest;
@@ -9,14 +10,17 @@ import com.onepiece.otboo.domain.user.entity.User;
 import com.onepiece.otboo.domain.user.enums.Provider;
 import com.onepiece.otboo.domain.user.enums.Role;
 import com.onepiece.otboo.domain.user.exception.DuplicateEmailException;
+import com.onepiece.otboo.domain.user.exception.UserNotFoundException;
 import com.onepiece.otboo.domain.user.mapper.UserMapper;
 import com.onepiece.otboo.domain.user.repository.UserRepository;
 import com.onepiece.otboo.global.dto.response.CursorPageResponseDto;
 import com.onepiece.otboo.global.exception.ErrorCode;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -103,6 +107,20 @@ public class UserServiceImpl implements UserService {
             sortBy, sortDirection);
     }
 
+    @Override
+    @PreAuthorize("hasRole('ADMIN')")
+    public UserDto updateUserRole(UUID userId, Role role) {
+        User user = findUser(userId);
+        Profile profile = findProfile(userId);
+
+        user.updateRole(role);
+        User updatedUser = userRepository.save(user);
+
+        log.info("[UserService] 권한 수정 실행 완료 - id: {}", updatedUser.getId());
+
+        return userMapper.toDto(updatedUser, profile);
+    }
+
     private Profile createProfile(User user, String name) {
         Profile profile = Profile.builder()
             .user(user)
@@ -110,5 +128,15 @@ public class UserServiceImpl implements UserService {
             .build();
 
         return profileRepository.save(profile);
+    }
+
+    private User findUser(UUID id) {
+        return userRepository.findById(id)
+            .orElseThrow(() -> UserNotFoundException.byId(id));
+    }
+
+    private Profile findProfile(UUID id) {
+        return profileRepository.findByUserId(id)
+            .orElseThrow(() -> new ProfileNotFoundException(id));
     }
 }

--- a/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
@@ -40,7 +40,10 @@ public enum ErrorCode {
 
     // LOCATION
     INVALID_COORDINATE(HttpStatus.BAD_REQUEST, "유효하지 않은 좌표 값입니다.", "위도와 경도를 확인해주세요."),
-    INVALID_AREA(HttpStatus.BAD_REQUEST, "서비스 지역이 아닙니다.", "해당 위치는 서비스 대상 지역이 아닙니다.");
+    INVALID_AREA(HttpStatus.BAD_REQUEST, "서비스 지역이 아닙니다.", "해당 위치는 서비스 대상 지역이 아닙니다."),
+
+    // PROFILE
+    PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 확인 실패", "해당 유저의 프로필을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 📌 작업 개요

- 사용자 권한 수정 기능 추가

## ✅ 완료한 작업

- [x] 사용자 권한 수정 기능 추가
- [x] ADMIN 권한을 가진 사용자만 권한 수정 가능 

## 🧪 테스트 결과

- 로컬 테스트 완료
<img width="1433" height="694" alt="image" src="https://github.com/user-attachments/assets/be7de788-4fa7-44a1-bd9d-79bb82e6109c" />

- ADMIN이 아닌 사용자는 다음과 같이 403 예외가 발생합니다.
<img width="1433" height="694" alt="image" src="https://github.com/user-attachments/assets/8a9340fb-4aee-4a2b-b007-189371d7c323" />

## ⚠️ 기타 참고 사항

-  계정 목록 조회도 ADMIN 계정만 가능한지 얘기하면 좋을 것 같습니다 :) ADMIN만 가능하다면 이 pr에 반영해서 커밋하겠습니다..!

---

## Related Issue

Closes #77


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 관리자 전용 사용자 역할 변경 API 추가: PATCH /api/users/{userId}/role
  * 요청 본문 유효성 검증(역할 필수) 및 잘못된 값 처리 강화
  * 프로필 미존재 시 404 반환을 위한 오류 코드 및 예외 추가
* Tests
  * 컨트롤러/서비스 테스트 보강: 성공, 유효성 실패(누락·잘못된 역할), 권한 거부, 미존재 사용자·프로필 시나리오 검증
  * 테스트 픽스처 활용으로 중복 감소 및 가독성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->