### PR TITLE
[Feature] 프로필 조회 기능 추가

### DIFF
--- a/src/integrationTest/java/com/onepiece/otboo/domain/user/controller/UserControllerIntegrationTest.java
+++ b/src/integrationTest/java/com/onepiece/otboo/domain/user/controller/UserControllerIntegrationTest.java
@@ -90,12 +90,12 @@ public class UserControllerIntegrationTest {
 
         ProfileDto profileDto = ProfileDtoFixture.createProfile(userId2);
 
-        given(profileService.getUserProfile(userId)).willReturn(profileDto);
+        given(profileService.getUserProfile(userId2)).willReturn(profileDto);
 
         CustomUserDetails principal = customUserDetails(userId, "ADMIN");
 
         // when
-        ResultActions result = mockMvc.perform(get("/api/users/{userId}/profiles", userId)
+        ResultActions result = mockMvc.perform(get("/api/users/{userId}/profiles", userId2)
             .with(user(principal)));
 
         // then

--- a/src/integrationTest/java/com/onepiece/otboo/domain/user/controller/UserControllerIntegrationTest.java
+++ b/src/integrationTest/java/com/onepiece/otboo/domain/user/controller/UserControllerIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.onepiece.otboo.domain.user.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.onepiece.otboo.domain.profile.dto.response.ProfileDto;
+import com.onepiece.otboo.domain.profile.fixture.ProfileDtoFixture;
+import com.onepiece.otboo.domain.profile.service.ProfileService;
+import com.onepiece.otboo.domain.user.enums.Role;
+import com.onepiece.otboo.infra.security.userdetails.CustomUserDetails;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@ActiveProfiles("prod")
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProfileService profileService;
+
+    private CustomUserDetails customUserDetails(UUID id, String role) {
+        return new CustomUserDetails(
+            id,
+            "me@test.com",
+            "{noop}pw",
+            Role.valueOf(role),
+            false,
+            null,
+            null
+        );
+    }
+
+    @Test
+    void 본인이_자신의_프로필_조회_요청시_200을_반환한다() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        ProfileDto profileDto = ProfileDtoFixture.createProfile(userId);
+
+        given(profileService.getUserProfile(userId)).willReturn(profileDto);
+
+        CustomUserDetails principal = customUserDetails(userId, "USER");
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/users/{userId}/profiles", userId)
+            .with(user(principal)));
+
+        // then
+        result.andExpect(status().isOk())
+            .andExpect(jsonPath("$.userId").value(userId.toString()));
+    }
+
+    @Test
+    void USER_권한을_가진_사용자는_다른_사용자의_프로필_조회_요청시_403을_반환한다() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID userId2 = UUID.randomUUID();
+
+        CustomUserDetails principal = customUserDetails(userId, "USER");
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/users/{userId}/profiles", userId2)
+            .with(user(principal)));
+
+        // then
+        result.andExpect(status().isForbidden());
+    }
+
+    @Test
+    void ADMIN_권한을_가진_사용자는_다른_사용자의_프로필_조회_요청시_200을_반환한다() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID userId2 = UUID.randomUUID();
+
+        ProfileDto profileDto = ProfileDtoFixture.createProfile(userId2);
+
+        given(profileService.getUserProfile(userId)).willReturn(profileDto);
+
+        CustomUserDetails principal = customUserDetails(userId, "ADMIN");
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/users/{userId}/profiles", userId)
+            .with(user(principal)));
+
+        // then
+        result.andExpect(status().isOk())
+            .andExpect(jsonPath("$.userId").value(userId2.toString()));
+    }
+}

--- a/src/main/java/com/onepiece/otboo/domain/profile/dto/response/ProfileDto.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/dto/response/ProfileDto.java
@@ -1,7 +1,7 @@
 package com.onepiece.otboo.domain.profile.dto.response;
 
-import com.onepiece.otboo.domain.location.entity.Location;
 import com.onepiece.otboo.domain.profile.enums.Gender;
+import com.onepiece.otboo.domain.weather.dto.data.WeatherAPILocation;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -10,7 +10,7 @@ public record ProfileDto(
     String name,
     Gender gender,
     LocalDate birthDate,
-    Location location,
+    WeatherAPILocation location,
     Integer temperatureSensitivity,
     String profileImageUrl
 ) {

--- a/src/main/java/com/onepiece/otboo/domain/profile/dto/response/ProfileDto.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/dto/response/ProfileDto.java
@@ -4,7 +4,9 @@ import com.onepiece.otboo.domain.profile.enums.Gender;
 import com.onepiece.otboo.domain.weather.dto.data.WeatherAPILocation;
 import java.time.LocalDate;
 import java.util.UUID;
+import lombok.Builder;
 
+@Builder
 public record ProfileDto(
     UUID userId,
     String name,

--- a/src/main/java/com/onepiece/otboo/domain/profile/exception/ProfileException.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/exception/ProfileException.java
@@ -1,0 +1,16 @@
+package com.onepiece.otboo.domain.profile.exception;
+
+import com.onepiece.otboo.global.exception.ErrorCode;
+import com.onepiece.otboo.global.exception.GlobalException;
+import java.util.Map;
+
+public class ProfileException extends GlobalException {
+
+    public ProfileException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ProfileException(ErrorCode errorCode, Map<String, Object> details) {
+        super(errorCode, details);
+    }
+}

--- a/src/main/java/com/onepiece/otboo/domain/profile/exception/ProfileNotFoundException.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/exception/ProfileNotFoundException.java
@@ -1,0 +1,12 @@
+package com.onepiece.otboo.domain.profile.exception;
+
+import com.onepiece.otboo.global.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class ProfileNotFoundException extends ProfileException {
+
+    public ProfileNotFoundException(UUID userId) {
+        super(ErrorCode.PROFILE_NOT_FOUND, Map.of("userId", userId));
+    }
+}

--- a/src/main/java/com/onepiece/otboo/domain/profile/mapper/ProfileMapper.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/mapper/ProfileMapper.java
@@ -1,0 +1,30 @@
+package com.onepiece.otboo.domain.profile.mapper;
+
+import com.onepiece.otboo.domain.profile.dto.response.ProfileDto;
+import com.onepiece.otboo.domain.profile.entity.Profile;
+import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.domain.weather.dto.data.WeatherAPILocation;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+
+@Mapper(componentModel = "spring")
+public interface ProfileMapper {
+
+    @Mapping(target = "userId", source = "user.id")
+    @Mapping(target = "name", source = "profile.nickname")
+    @Mapping(target = "gender", source = "profile.gender")
+    @Mapping(target = "birthDate", source = "profile.birthDate")
+    @Mapping(target = "location", expression = "java(toWeatherAPILocation(profile))")
+    @Mapping(target = "temperatureSensitivity", source = "profile.tempSensitivity")
+    @Mapping(target = "profileImageUrl", source = "profile.profileImageUrl")
+    ProfileDto toDto(User user, Profile profile);
+
+    // Location → WeatherAPILocation 변환
+    default WeatherAPILocation toWeatherAPILocation(Profile profile) {
+        if (profile.getLocation() == null) {
+            return null;
+        }
+        return WeatherAPILocation.toDto(profile.getLocation());
+    }
+}

--- a/src/main/java/com/onepiece/otboo/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/service/ProfileService.java
@@ -1,0 +1,9 @@
+package com.onepiece.otboo.domain.profile.service;
+
+import com.onepiece.otboo.domain.profile.dto.response.ProfileDto;
+import java.util.UUID;
+
+public interface ProfileService {
+
+    ProfileDto getUserProfile(UUID userId);
+}

--- a/src/main/java/com/onepiece/otboo/domain/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/service/ProfileServiceImpl.java
@@ -1,0 +1,45 @@
+package com.onepiece.otboo.domain.profile.service;
+
+import com.onepiece.otboo.domain.profile.dto.response.ProfileDto;
+import com.onepiece.otboo.domain.profile.entity.Profile;
+import com.onepiece.otboo.domain.profile.exception.ProfileNotFoundException;
+import com.onepiece.otboo.domain.profile.mapper.ProfileMapper;
+import com.onepiece.otboo.domain.profile.repository.ProfileRepository;
+import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.domain.user.exception.UserNotFoundException;
+import com.onepiece.otboo.domain.user.repository.UserRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProfileServiceImpl implements ProfileService {
+
+    private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
+    private final ProfileMapper profileMapper;
+
+    @Transactional(readOnly = true)
+    public ProfileDto getUserProfile(UUID userId) {
+        User user = findUser(userId);
+        Profile profile = findProfile(userId);
+
+        log.info("[ProfileService] 프로필 조회 완료 - userId: {}", userId);
+
+        return profileMapper.toDto(user, profile);
+    }
+
+    private User findUser(UUID userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> UserNotFoundException.byId(userId));
+    }
+
+    private Profile findProfile(UUID userId) {
+        return profileRepository.findByUserId(userId)
+            .orElseThrow(() -> new ProfileNotFoundException(userId));
+    }
+}

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.onepiece.otboo.domain.user.controller;
 
+import com.onepiece.otboo.domain.profile.dto.response.ProfileDto;
+import com.onepiece.otboo.domain.profile.service.ProfileService;
 import com.onepiece.otboo.domain.user.controller.api.UserApi;
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.request.UserGetRequest;
@@ -7,13 +9,15 @@ import com.onepiece.otboo.domain.user.dto.response.UserDto;
 import com.onepiece.otboo.domain.user.service.UserService;
 import com.onepiece.otboo.global.dto.response.CursorPageResponseDto;
 import jakarta.validation.Valid;
-import java.util.Locale;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserApi {
 
     private final UserService userService;
+    private final ProfileService profileService;
 
     @Override
     @PostMapping
@@ -54,6 +59,20 @@ public class UserController implements UserApi {
 
         log.info("[UserController] 계정 목록 조회 성공 - {}개의 데이터, 다음 페이지 존재 여부: {}",
             result.data().size(), result.hasNext());
+
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    @Override
+    @PreAuthorize("#userId == principal.userId or hasRole('ADMIN')")
+    @GetMapping("/{userId}/profiles")
+    public ResponseEntity<ProfileDto> getUserProfile(@PathVariable UUID userId) {
+
+        log.info("[UserController] 프로필 조회 요청 - userId: {}", userId);
+
+        ProfileDto result = profileService.getUserProfile(userId);
+
+        log.info("[UserController] 프로필 조회 완료 - userId: {} nickname: {}", userId, result.name());
 
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -85,7 +85,7 @@ public interface UserApi {
             )
         ),
         @ApiResponse(
-            responseCode = "400", description = "프로필 조회 실패",
+            responseCode = "404", description = "프로필 조회 실패",
             content = @Content(
                 mediaType = "*/*",
                 schema = @Schema(implementation = ErrorResponse.class)

--- a/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/onepiece/otboo/domain/user/controller/api/UserApi.java
@@ -1,5 +1,6 @@
 package com.onepiece.otboo.domain.user.controller.api;
 
+import com.onepiece.otboo.domain.profile.dto.response.ProfileDto;
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.request.UserGetRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
@@ -14,8 +15,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "프로필 관리", description = "프로필 관련 API")
@@ -66,4 +69,35 @@ public interface UserApi {
         )
     })
     ResponseEntity<CursorPageResponseDto<UserDto>> getUsers(@Valid @ModelAttribute UserGetRequest request);
+
+
+    @Operation(
+        summary = "프로필 조회"
+        , description = "프로필 조회 API"
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200", description = "프로필 조회 성공",
+            content = @Content(
+                mediaType = "*/*",
+                array = @ArraySchema(schema = @Schema(implementation = ProfileDto.class))
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400", description = "프로필 조회 실패",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "403", description = "권한 부족",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<ProfileDto> getUserProfile(@PathVariable UUID userId);
 }

--- a/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/com/onepiece/otboo/global/exception/ErrorCode.java
@@ -40,7 +40,10 @@ public enum ErrorCode {
 
     // LOCATION
     INVALID_COORDINATE(HttpStatus.BAD_REQUEST, "유효하지 않은 좌표 값입니다.", "위도와 경도를 확인해주세요."),
-    INVALID_AREA(HttpStatus.BAD_REQUEST, "서비스 지역이 아닙니다.", "해당 위치는 서비스 대상 지역이 아닙니다.");
+    INVALID_AREA(HttpStatus.BAD_REQUEST, "서비스 지역이 아닙니다.", "해당 위치는 서비스 대상 지역이 아닙니다."),
+
+    /// PROFILE
+    PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 확인 실패", "해당 유저의 프로필을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/com/onepiece/otboo/domain/profile/fixture/ProfileDtoFixture.java
+++ b/src/test/java/com/onepiece/otboo/domain/profile/fixture/ProfileDtoFixture.java
@@ -1,0 +1,23 @@
+package com.onepiece.otboo.domain.profile.fixture;
+
+import com.onepiece.otboo.domain.profile.dto.response.ProfileDto;
+import com.onepiece.otboo.domain.profile.enums.Gender;
+import com.onepiece.otboo.domain.weather.dto.data.WeatherAPILocation;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public class ProfileDtoFixture {
+
+    public static ProfileDto createProfile(UUID userId) {
+        return ProfileDto.builder()
+            .userId(userId)
+            .name("test")
+            .gender(Gender.MALE)
+            .birthDate(LocalDate.of(1999, 7, 2))
+            .location(new WeatherAPILocation(37.5665, 126.9780, 60, 127, List.of("서울", "중구")))
+            .temperatureSensitivity(5)
+            .profileImageUrl("http://example.com/profile.png")
+            .build();
+    }
+}

--- a/src/test/java/com/onepiece/otboo/domain/profile/fixture/ProfileFixture.java
+++ b/src/test/java/com/onepiece/otboo/domain/profile/fixture/ProfileFixture.java
@@ -1,7 +1,9 @@
 package com.onepiece.otboo.domain.profile.fixture;
 
+import com.onepiece.otboo.domain.location.fixture.LocationFixture;
 import com.onepiece.otboo.domain.profile.entity.Profile;
 import com.onepiece.otboo.domain.profile.enums.Gender;
+import com.onepiece.otboo.domain.user.entity.User;
 import com.onepiece.otboo.domain.user.fixture.UserFixture;
 import java.time.LocalDate;
 
@@ -16,6 +18,18 @@ public class ProfileFixture {
             .tempSensitivity(5)
             .user(UserFixture.createUser())
             .location(null)
+            .build();
+    }
+
+    public static Profile createProfile(User user) {
+        return Profile.builder()
+            .nickname("test")
+            .profileImageUrl("https://example.com/image.png")
+            .gender(Gender.MALE)
+            .birthDate(LocalDate.of(1999, 7, 2))
+            .tempSensitivity(5)
+            .user(user)
+            .location(LocationFixture.createLocation())
             .build();
     }
 }

--- a/src/test/java/com/onepiece/otboo/domain/profile/service/ProfileServiceImplTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/profile/service/ProfileServiceImplTest.java
@@ -1,0 +1,117 @@
+package com.onepiece.otboo.domain.profile.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.onepiece.otboo.domain.profile.dto.response.ProfileDto;
+import com.onepiece.otboo.domain.profile.entity.Profile;
+import com.onepiece.otboo.domain.profile.exception.ProfileNotFoundException;
+import com.onepiece.otboo.domain.profile.fixture.ProfileDtoFixture;
+import com.onepiece.otboo.domain.profile.fixture.ProfileFixture;
+import com.onepiece.otboo.domain.profile.mapper.ProfileMapper;
+import com.onepiece.otboo.domain.profile.repository.ProfileRepository;
+import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.domain.user.exception.UserNotFoundException;
+import com.onepiece.otboo.domain.user.fixture.UserFixture;
+import com.onepiece.otboo.domain.user.repository.UserRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private ProfileMapper profileMapper;
+
+    @InjectMocks
+    private ProfileServiceImpl profileService;
+
+    private UUID userId;
+    private User user;
+    private Profile profile;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        user = UserFixture.createUser("test@test.com");
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        profile = ProfileFixture.createProfile(user);
+    }
+
+    @Test
+    void 프로필_조회_성공_테스트() {
+
+        // given
+        ProfileDto profileDto = ProfileDtoFixture.createProfile(userId);
+
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(profileRepository.findByUserId(any())).willReturn(Optional.of(profile));
+        given(profileMapper.toDto(any(User.class), any(Profile.class))).willReturn(profileDto);
+
+        // when
+        ProfileDto result = profileService.getUserProfile(userId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(userId, result.userId());
+        assertEquals("test", result.name());
+        assertEquals("1999-07-02", result.birthDate().toString());
+        verify(userRepository).findById(userId);
+        verify(profileRepository).findByUserId(userId);
+        verify(profileMapper).toDto(user, profile);
+    }
+
+    @Test
+    void 존재하지_않는_사용자의_프로필_조회_요청시_예외가_발생한다() {
+
+        // given
+        UUID notExistId = UUID.randomUUID();
+
+        given(userRepository.findById(notExistId)).willReturn(Optional.empty());
+
+        // when
+        Throwable thrown = catchThrowable(() -> profileService.getUserProfile(notExistId));
+
+        // then
+        assertThat(thrown)
+            .isInstanceOf(UserNotFoundException.class)
+            .hasMessageContaining("사용자");
+        verify(profileMapper, never()).toDto(any(), any());
+    }
+
+    @Test
+    void 특정_사용자의_프로필이_존재하지_않을_때_예외가_발생한다() {
+
+        // given
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(profileRepository.findByUserId(any())).willReturn(Optional.empty());
+
+        // when
+        Throwable thrown = catchThrowable(() -> profileService.getUserProfile(userId));
+
+        // then
+        assertThat(thrown)
+            .isInstanceOf(ProfileNotFoundException.class)
+            .hasMessageContaining("프로필");
+        verify(profileMapper, never()).toDto(any(), any());
+    }
+}

--- a/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/user/controller/UserControllerTest.java
@@ -11,6 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onepiece.otboo.domain.profile.dto.response.ProfileDto;
+import com.onepiece.otboo.domain.profile.fixture.ProfileDtoFixture;
+import com.onepiece.otboo.domain.profile.service.ProfileService;
 import com.onepiece.otboo.domain.user.dto.request.UserCreateRequest;
 import com.onepiece.otboo.domain.user.dto.request.UserGetRequest;
 import com.onepiece.otboo.domain.user.dto.response.UserDto;
@@ -31,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -49,6 +53,9 @@ class UserControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @MockitoBean
+    private ProfileService profileService;
 
     @Autowired
     private ObjectMapper objectMapper;


### PR DESCRIPTION
## 📌 작업 개요

- 프로필 조회 기능 추가

## ✅ 완료한 작업

- [x] 프로필 조회 기능 추가
- [x] `ADMIN` 권한을 가진 사용자와 자신만 자신의 프로
- [x] 더미 `ProfileDto`를 생성하는 `ProfileDtoFixture` 추가
 
## 🧪 테스트 결과
<img width="1433" height="694" alt="스크린샷 2025-09-23 오후 10 47 54" src="https://github.com/user-attachments/assets/5dbcee1d-c83c-4e33-85e4-3478ee47f614" />
<img width="1433" height="694" alt="스크린샷 2025-09-23 오후 11 21 41" src="https://github.com/user-attachments/assets/48e578da-0f27-4b7a-8baa-e6f068ec38fa" />

## ⚠️ 기타 참고 사항

- 권한 확인을 위해 `@PreAuthorize`를 사용했는데 단위 테스트가 까다로워서 `intergrationTest` 패키지에 통합테스트로 테스트 완료했습니다.

- 권한이 없는 사용자가 다른 사람의 프로필 조회 요청시 403 예외를 발생하는 것은 Postman을 통해 확인했습니다 :)

---

## Related Issue

Closes #83 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 사용자 프로필 조회 API 추가: GET /api/users/{userId}/profiles. 본인은 자신의 프로필 조회 가능, ADMIN은 타 사용자 조회 가능; 권한 없는 접근은 403, 프로필 미존재 시 404 반환.
  - 프로필 응답의 위치 정보 스키마를 WeatherAPI 기반 구조로 변경(좌표·정확도·지명 목록 포함).
  - 프로필 조회 서비스 및 매퍼/DTO 빌더 지원 추가.
- 오류 처리
  - 프로필 관련 전용 예외 및 PROFILE_NOT_FOUND 에러 코드 추가.
- 테스트
  - 통합·단위 테스트와 테스트 픽스처로 권한·예외·매핑 동작 검증 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->