### PR TITLE
[Feature] 프로필 업데이트 시 이미지 업로드 비동기 처리

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/profile/service/ProfileImageAsyncService.java
+++ b/src/main/java/com/onepiece/otboo/domain/profile/service/ProfileImageAsyncService.java
@@ -1,0 +1,54 @@
+package com.onepiece.otboo.domain.profile.service;
+
+import com.onepiece.otboo.domain.profile.entity.Profile;
+import com.onepiece.otboo.domain.profile.exception.ProfileNotFoundException;
+import com.onepiece.otboo.domain.profile.repository.ProfileRepository;
+import com.onepiece.otboo.global.storage.S3Storage;
+import com.onepiece.otboo.global.storage.payload.UploadPayload;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProfileImageAsyncService {
+
+    private final ProfileRepository profileRepository;
+    private final S3Storage storage;
+
+    @Async("binaryContentExecutor")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void replaceProfileImageAsync(UUID userId, String prefix, UploadPayload payload,
+        String oldKey) {
+        try {
+            // 업로드
+            String newKey = storage.uploadBytes(prefix, payload);
+
+            // 프로필 재조회 & 반영
+            Profile profile = profileRepository.findByUserId(userId)
+                .orElseThrow(() -> new ProfileNotFoundException(userId));
+            profile.updateProfileImageUrl(newKey);
+
+            // 이전 키 삭제
+            if (oldKey != null && !oldKey.equals(newKey)) {
+                try {
+                    storage.deleteFile(oldKey);
+                } catch (Exception e) {
+                    log.warn("[ProfileImageAsync] 이전 이미지 삭제 실패 - key: {}", oldKey, e);
+                }
+            }
+
+            log.info("[ProfileImageAsync] 비동기 업로드 완료 - userId: {}, newKey: {}", userId, newKey);
+        } catch (IOException e) {
+            log.error("[ProfileImageAsync] 비동기 업로드 실패(IO) - userId: {}", userId, e);
+        } catch (Exception e) {
+            log.error("[ProfileImageAsync] 비동기 업로드 실패 - userId: {}", userId, e);
+        }
+    }
+}

--- a/src/main/java/com/onepiece/otboo/global/config/AsyncConfig.java
+++ b/src/main/java/com/onepiece/otboo/global/config/AsyncConfig.java
@@ -1,12 +1,54 @@
 package com.onepiece.otboo.global.config;
 
+import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
 @EnableRetry
 public class AsyncConfig {
 
+    @Bean(name = "binaryContentExecutor")
+    public ThreadPoolTaskExecutor binaryContentExecutor(
+        @Value("${async.executors.binary-content.core-size}") int core,
+        @Value("${async.executors.binary-content.max-size}") int max,
+        @Value("${async.executors.binary-content.queue-capacity}") int queue,
+        @Value("${async.executors.binary-content.keep-alive}") int keepAlive) {
+
+        return buildExecutor(core, max, queue, keepAlive, "binaryContent-exec");
+    }
+
+    /**
+     * ThreadPoolTaskExecutor 공통 빌더
+     *
+     * @param core      항상 유지되는 최소 스레드 수
+     * @param max       최대 스레드 수
+     * @param queue     작업을 대기시킬 큐의 크기 -> corePoolSize 만큼 스레드가 모두 사용 중일 때 새로운 작업들이 대기
+     * @param keepAlive 유휴 스레드의 생존 시간
+     * @param prefix    생성되는 스레드의 이름 접두사
+     * @return ThreadPoolTaskExecutor 객체
+     */
+    private ThreadPoolTaskExecutor buildExecutor(int core, int max, int queue, int keepAlive,
+        String prefix) {
+
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(core);
+        executor.setMaxPoolSize(max);
+        executor.setQueueCapacity(queue);
+        executor.setKeepAliveSeconds(keepAlive);
+        executor.setThreadNamePrefix(prefix + "-");
+        executor.setRejectedExecutionHandler(new CallerRunsPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(20);
+
+        executor.initialize();
+
+        return executor;
+    }
 }

--- a/src/main/java/com/onepiece/otboo/global/storage/FileStorage.java
+++ b/src/main/java/com/onepiece/otboo/global/storage/FileStorage.java
@@ -1,11 +1,14 @@
 package com.onepiece.otboo.global.storage;
 
+import com.onepiece.otboo.global.storage.payload.UploadPayload;
 import java.io.IOException;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface FileStorage {
 
     String uploadFile(String prefix, MultipartFile image) throws IOException;
+
+    String uploadBytes(String prefix, UploadPayload payload) throws IOException;
 
     void deleteFile(String key);
 }

--- a/src/main/java/com/onepiece/otboo/global/storage/S3Storage.java
+++ b/src/main/java/com/onepiece/otboo/global/storage/S3Storage.java
@@ -12,13 +12,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
@@ -55,20 +56,7 @@ public class S3Storage implements FileStorage {
 
         String key = buildKey(prefix, image.getOriginalFilename());
 
-        // 메타 데이터 설정
-        PutObjectRequest putRequest = buildPutRequest(key);
-
-        try {
-            s3Client.putObject(putRequest, RequestBody.fromBytes(image.getBytes()));
-        } catch (S3Exception e) {
-            log.error("S3 업로드 실패 - S3 서비스 오류 발생", e);
-
-            throw e;
-        } catch (IOException e) {
-            log.error("S3 업로드 실패 - 파일 업로드 오류 발생", e);
-
-            throw e;
-        }
+        uploadInternal(key, image.getBytes());
 
         return key;
     }
@@ -80,17 +68,8 @@ public class S3Storage implements FileStorage {
 
         String key = buildKey(prefix, payload.originalFilename());
 
-        PutObjectRequest putRequest = buildPutRequest(key);
+        uploadInternal(key, payload.bytes());
 
-        try {
-            s3Client.putObject(putRequest, RequestBody.fromBytes(payload.bytes()));
-        } catch (S3Exception e) {
-            log.error("S3 업로드 실패 - S3 서비스 오류 발생", e);
-            throw e;
-        } catch (Exception e) {
-            log.error("S3 업로드 실패 - 파일 업로드 오류 발생", e);
-            throw e;
-        }
         return key;
     }
 
@@ -155,5 +134,18 @@ public class S3Storage implements FileStorage {
             .bucket(bucket)
             .key(key)
             .build();
+    }
+
+    private void uploadInternal(String key, byte[] bytes) {
+        PutObjectRequest putRequest = buildPutRequest(key);
+        try {
+            s3Client.putObject(putRequest, RequestBody.fromBytes(bytes));
+        } catch (AwsServiceException e) { // 서버측(Service) 예외
+            log.error("S3 업로드 실패 - S3 서비스 오류 발생 key: {}", key, e);
+            throw e;
+        } catch (SdkClientException e) {   // 클라이언트측(SDK) 예외
+            log.error("S3 업로드 실패 - SDK 클라이언트 오류 발생 key: {}", key, e);
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/onepiece/otboo/global/storage/payload/UploadPayload.java
+++ b/src/main/java/com/onepiece/otboo/global/storage/payload/UploadPayload.java
@@ -1,0 +1,10 @@
+package com.onepiece.otboo.global.storage.payload;
+
+public record UploadPayload(
+    byte[] bytes,
+    String originalFilename,
+    String contentType,
+    long size
+) {
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -103,3 +103,11 @@ aws:
     prefix:
       profile: ${PROFILE_PREFIX}
       clothes: ${CLOTHES_PREFIX}
+
+async:
+  executors:
+    binary-content:
+      core-size: ${MAX_CORE_SIZE:4}
+      max-size: ${MAX_SIZE:8}
+      queue-capacity: ${QUEUE_CAPACITY:200}
+      keep-alive: ${KEEP_ALIVE:60}


### PR DESCRIPTION
## 📌 작업 개요

- 프로필 업데이트 시 이미지 업로드 비동기 처리

## ✅ 완료한 작업

- [x] `AsyncConfig` 추가
- [x] 이미지 업로드 비동기 처리를 위한 `ProfileService` 책임 분리
- [x] `S3Storage`에 바이트 단위 파일 업로드 메서드 추가

## 🧪 테스트 결과

이미지 업로드 동기 처리 시 495ms 소요
<img width="1348" height="640" alt="image" src="https://github.com/user-attachments/assets/9095c704-d7cf-42b0-bc6d-49dc8fbc8ead" />

이미지 업로드 비동기 처리 시 56~112ms 소요
<img width="1348" height="640" alt="image" src="https://github.com/user-attachments/assets/7074a845-f27d-47e2-b7c2-83b22e4b044a" />

## ⚠️ 기타 참고 사항

- 비동기 처리를 이벤트 기반 처리 방식으로 바꿀 예정이라 `ProfileImageAsyncService` 클래스의 테스트 코드는 따로 작성하지 않았습니다.

---

## Related Issue

Closes #101 
