### PR TITLE
[Fix] 의상 수정 시 의상 속성값 초기화되는 오류 수정

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/clothes/service/ClothesServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/clothes/service/ClothesServiceImpl.java
@@ -215,6 +215,8 @@ public class ClothesServiceImpl implements ClothesService {
         Clothes clothes = clothesRepository.findById(clothesId)
             .orElseThrow(() -> new ClothesNotFoundException("의상 정보를 찾을 수 없습니다. id: " + clothesId));
 
+        String oldImageUrl = clothes.getImageUrl();
+
         String newName = request.name();
         ClothesType newType = request.type();
         String newImageUrl = null;
@@ -250,6 +252,15 @@ public class ClothesServiceImpl implements ClothesService {
         clothes.update(newName, newType, newImageUrl);
 
         Clothes updatedClothes = clothesRepository.save(clothes);
+
+        if (newImageUrl != null && oldImageUrl != null && !oldImageUrl.isBlank()) {
+            try {
+                fileStorage.deleteFile(oldImageUrl);
+            } catch (Exception e) {
+                log.warn("기존 이미지 삭제 실패: {}", oldImageUrl, e);
+                // 삭제 실패는 치명적이지 않으므로 계속 진행
+            }
+        }
 
         List<ClothesAttributeWithDefDto> clothesAttributeWithDefDto =
             attributes.stream().map(a -> {


### PR DESCRIPTION
## 📌 작업 개요

- 의상 수정 시 의상 속성값 초기화되는 오류 수정

## ✅ 완료한 작업

- 의상 수정 메서드에 의상 속성값 업데이트 코드 추가

## 🧪 테스트 결과

- 로컬 테스트 완료

## ⚠️ 기타 참고 사항

---

## Related Issue

Closes #124 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 의류 정보 업데이트 시 속성 정보가 API 응답에 제대로 포함되도록 수정
  * 이미지 업로드 및 이전 이미지 정리 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->