### PR TITLE
[Chore]: dev, prod 환경에서 kafka 설정 분리

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -11,6 +11,19 @@ spring:
       ddl-auto: create-drop
     show-sql: true
     database-platform: org.hibernate.dialect.H2Dialect
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      group-id: ${SPRING_KAFKA_CONSUMER_GROUP_ID:onepiece-group}
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      properties:
+        isolation.level: read_committed
+      enable-auto-commit: false
 
 logging:
   level:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -14,6 +14,31 @@ spring:
       ddl-auto: validate
     show-sql: false
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    properties:
+      security.protocol: SASL_SSL
+      sasl.mechanism: PLAIN
+      sasl.jaas.config: >
+        org.apache.kafka.common.security.plain.PlainLoginModule required
+        username="${KAFKA_API_KEY}"
+        password="${KAFKA_API_SECRET}";
+      ssl.endpoint.identification.algorithm: https
+      client.dns.lookup: use_all_dns_ips
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      group-id: ${SPRING_KAFKA_CONSUMER_GROUP_ID:onepiece-group}
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      properties:
+        isolation.level: read_committed
+      enable-auto-commit: false
+
+server:
+  port: ${SERVER_PORT:80}
 
 logging:
   level:
@@ -25,13 +50,16 @@ otboo:
   security:
     cors:
       allowed-origins:
-        - "https://prod.otboo.com"
+        - "https://otboo.site"
+        - "http://otboo.site"
         - "http://localhost:3000"
       allowed-methods:
         - GET
         - POST
         - PUT
         - DELETE
+        - PATCH
+        - OPTIONS
       allow-credentials: true
     csrf:
       ignored-paths:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,28 +77,6 @@ spring:
       port: ${REDIS_PORT:6379}
   cache:
     type: redis
-  kafka:
-    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-    properties:
-      security.protocol: SASL_SSL
-      sasl.mechanism: PLAIN
-      sasl.jaas.config: >
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="${KAFKA_API_KEY}"
-        password="${KAFKA_API_SECRET}";
-      ssl.endpoint.identification.algorithm: https
-      client.dns.lookup: use_all_dns_ips
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.StringSerializer
-    consumer:
-      group-id: ${SPRING_KAFKA_CONSUMER_GROUP_ID:onepiece-group}
-      auto-offset-reset: earliest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      properties:
-        isolation.level: read_committed
-      enable-auto-commit: false
 
 logging:
   level:


### PR DESCRIPTION
## 📌 작업 개요

- dev, prod 환경에서 kafka 설정 분리

## ✅ 완료한 작업

- kafka 설정 분리를 위한 `application.yaml`, `application-dev.yaml`, `application-prod.yaml` 수정 
- 기능 B 테스트 코드 작성

## 🧪 테스트 결과


## ⚠️ 기타 참고 사항

- dev 프로필에서 local로 실행 시 env 파일에 있는 `SPRING_KAFKA_BOOTSTRAP_SERVERS` 환경 변수를 주석처리 해야합니다. 참고 부탁드립니다!

---

## Related Issue

Closes #157 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Kafka 메시징 인프라 구성 설정 추가 (개발 및 프로덕션 환경)
  * 서버 포트 설정 구성 추가
  * CORS 도메인 정책 업데이트 (otboo.site 추가)
  * 기존 Kafka 설정 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->