### PR TITLE
[Fix] 피드 좋아요, 댓글 작성 시 알림 생성 이벤트 발행 기능 수정 

### DIFF
--- a/src/main/java/com/onepiece/otboo/domain/comment/service/CommentService.java
+++ b/src/main/java/com/onepiece/otboo/domain/comment/service/CommentService.java
@@ -8,10 +8,13 @@ import com.onepiece.otboo.domain.comment.repository.CommentRepository;
 import com.onepiece.otboo.domain.feed.entity.Feed;
 import com.onepiece.otboo.domain.feed.repository.FeedRepository;
 import com.onepiece.otboo.domain.user.entity.User;
+import com.onepiece.otboo.global.event.event.FeedCommentCreatedEvent;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +27,7 @@ public class CommentService {
     private final CommentRepository repository;
     private final CommentMapper mapper;
     private final FeedRepository feedRepository;
+    private final ApplicationEventPublisher publisher;
 
     public CommentDto create(UUID feedIdFromPath, CommentCreateRequest req) {
         if (req.feedId() != null && !req.feedId().equals(feedIdFromPath)) {
@@ -57,6 +61,8 @@ public class CommentService {
 
         feedRepository.increaseCommentCount(feedIdFromPath, 1L);
 
+        publisher.publishEvent(new FeedCommentCreatedEvent(dto, Instant.now()));
+        
         return dto;
     }
 }

--- a/src/main/java/com/onepiece/otboo/domain/feed/service/FeedLikeService.java
+++ b/src/main/java/com/onepiece/otboo/domain/feed/service/FeedLikeService.java
@@ -8,9 +8,7 @@ import com.onepiece.otboo.domain.feed.repository.FeedLikeRepository;
 import com.onepiece.otboo.domain.feed.repository.FeedRepository;
 import com.onepiece.otboo.domain.profile.entity.Profile;
 import com.onepiece.otboo.domain.profile.repository.ProfileRepository;
-import com.onepiece.otboo.domain.user.dto.response.UserDto;
 import com.onepiece.otboo.domain.user.entity.User;
-import com.onepiece.otboo.domain.user.mapper.UserMapper;
 import com.onepiece.otboo.domain.user.repository.UserRepository;
 import com.onepiece.otboo.global.event.event.FeedLikedEvent;
 import com.onepiece.otboo.global.exception.ErrorCode;
@@ -34,7 +32,6 @@ public class FeedLikeService {
     private final FeedLikeRepository feedLikeRepository;
     private final UserRepository userRepository;
     private final ProfileRepository profileRepository;
-    private final UserMapper userMapper;
     private final EntityManager em;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -74,10 +71,8 @@ public class FeedLikeService {
             false
         );
 
-        UserDto likerDto = userMapper.toDto(liker, null);
-
         eventPublisher.publishEvent(
-            new FeedLikedEvent(feedResponse, likerDto, Instant.now())
+            new FeedLikedEvent(feedResponse, userId, Instant.now())
         );
     }
 

--- a/src/main/java/com/onepiece/otboo/domain/notification/entity/Notification.java
+++ b/src/main/java/com/onepiece/otboo/domain/notification/entity/Notification.java
@@ -44,9 +44,6 @@ public class Notification {
     @Column(nullable = false, updatable = false)
     private Instant createdAt;
 
-    @Column
-    private Instant deletedAt;
-
     @Builder
     public Notification(UUID receiverId, String title, String content,
         Level level, Instant createdAt) {
@@ -55,12 +52,6 @@ public class Notification {
         this.content = content;
         this.level = level;
         this.createdAt = createdAt != null ? createdAt : Instant.now();
-    }
-
-    public void delete() {
-        if (this.deletedAt == null) {
-            this.deletedAt = Instant.now();
-        }
     }
 
     @Override

--- a/src/main/java/com/onepiece/otboo/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/onepiece/otboo/domain/notification/service/NotificationServiceImpl.java
@@ -102,7 +102,7 @@ public class NotificationServiceImpl implements NotificationService {
                 .build();
 
             Notification saved = notificationRepository.save(notification);
-            
+
             NotificationResponse response = notificationMapper.toResponse(saved);
 
             try {
@@ -125,6 +125,6 @@ public class NotificationServiceImpl implements NotificationService {
         Notification notification = notificationRepository.findById(id)
             .orElseThrow(() -> new NotificationNotFoundException(id));
 
-        notification.delete();
+        notificationRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/onepiece/otboo/global/batch/BatchScheduler.java
+++ b/src/main/java/com/onepiece/otboo/global/batch/BatchScheduler.java
@@ -17,8 +17,8 @@ public class BatchScheduler {
     private final JobLauncher jobLauncher;
     private final Job collectWeatherJob;
 
-    //@Scheduled(cron = "0 15 0,6,12,18 * * *", zone = "Asia/Seoul")
-    @Scheduled(cron = "0 */1 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 15 0,6,12,18 * * *", zone = "Asia/Seoul")
+    //@Scheduled(cron = "0 */1 * * * *", zone = "Asia/Seoul")
     public void runCollectWeatherJob() {
         try {
             JobParameters params = new JobParametersBuilder()

--- a/src/main/java/com/onepiece/otboo/global/event/event/FeedLikedEvent.java
+++ b/src/main/java/com/onepiece/otboo/global/event/event/FeedLikedEvent.java
@@ -1,12 +1,12 @@
 package com.onepiece.otboo.global.event.event;
 
 import com.onepiece.otboo.domain.feed.dto.response.FeedResponse;
-import com.onepiece.otboo.domain.user.dto.response.UserDto;
 import java.time.Instant;
+import java.util.UUID;
 
 public record FeedLikedEvent(
     FeedResponse feed,
-    UserDto liker,
+    UUID likerId,
     Instant createdAt
 ) {
 

--- a/src/main/java/com/onepiece/otboo/global/event/kafka/NotificationRequiredTopicListener.java
+++ b/src/main/java/com/onepiece/otboo/global/event/kafka/NotificationRequiredTopicListener.java
@@ -169,11 +169,10 @@ public class NotificationRequiredTopicListener {
             FeedLikedEvent.class,
             event -> {
                 var feed = event.feed();
-                var liker = event.liker();
+                UUID likerId = event.likerId();
 
                 UUID feedAuthorId = feed.author().userId();
                 String feedAuthorName = feed.author().name();
-                UUID likerId = liker.id();
 
                 if (likerId.equals(feedAuthorId)) {
                     log.debug("[NotificationRequiredTopicListener] 자기 피드 좋아요, 알림 생략 - userId={}",
@@ -181,16 +180,18 @@ public class NotificationRequiredTopicListener {
                     return;
                 }
 
+                Profile liker = findProfile(likerId);
+
                 notificationService.create(
                     Set.of(feedAuthorId),
                     "피드 좋아요",
-                    liker.name() + "님이 당신의 피드를 좋아했습니다.",
+                    liker.getNickname() + "님이 당신의 피드를 좋아했습니다.",
                     Level.INFO
                 );
 
                 log.debug(
-                    "[NotificationRequiredTopicListener] FeedLikedEvent 처리 완료 - feedAuthorId={}, liker={}",
-                    feedAuthorName, liker.name());
+                    "[NotificationRequiredTopicListener] FeedLikedEvent 처리 완료 - feedAuthorName={}, liker={}",
+                    feedAuthorName, liker.getNickname());
             }
         );
     }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -11,19 +11,6 @@ spring:
       ddl-auto: create-drop
     show-sql: true
     database-platform: org.hibernate.dialect.H2Dialect
-  kafka:
-    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.StringSerializer
-    consumer:
-      group-id: ${SPRING_KAFKA_CONSUMER_GROUP_ID:onepiece-group}
-      auto-offset-reset: earliest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      properties:
-        isolation.level: read_committed
-      enable-auto-commit: false
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,6 +31,19 @@ spring:
           timeout: 5000
           starttls:
             enable: true
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      group-id: ${SPRING_KAFKA_CONSUMER_GROUP_ID:onepiece-group}
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      properties:
+        isolation.level: read_committed
+      enable-auto-commit: false
 
   security:
     oauth2:

--- a/src/test/java/com/onepiece/otboo/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/comment/service/CommentServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
@@ -41,6 +42,8 @@ class CommentServiceTest {
     EntityManager em;
     @Mock
     FeedRepository feedRepository;
+    @Mock
+    ApplicationEventPublisher publisher;
 
     @InjectMocks
     CommentService service;

--- a/src/test/java/com/onepiece/otboo/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/feed/service/FeedServiceTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -274,22 +273,5 @@ class FeedServiceTest {
         assertThatExceptionOfType(GlobalException.class)
             .isThrownBy(() -> feedService.delete(feedId, UUID.randomUUID()))
             .matches(ex -> ((GlobalException) ex).getErrorCode() == ErrorCode.FEED_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("좋아요 등록 시 FeedLikedEvent가 발행된다")
-    void like_성공시_이벤트_발행() {
-        UUID userId = UUID.randomUUID();
-        UUID feedId = UUID.randomUUID();
-
-        Feed feed = mock(Feed.class);
-        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
-        when(feed.getAuthorId()).thenReturn(UUID.randomUUID());
-        when(profileRepository.findByUserId(any())).thenReturn(Optional.of(mock(Profile.class)));
-
-        feedLikeService.like(userId, feedId);
-
-        verify(feedLikeRepository).save(any());
-        verify(eventPublisher).publishEvent(any());
     }
 }

--- a/src/test/java/com/onepiece/otboo/domain/notification/entity/NotificationTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/notification/entity/NotificationTest.java
@@ -34,8 +34,6 @@ class NotificationTest {
         assertThat(notification.getCreatedAt()).isNotNull();
         assertThat(notification.getCreatedAt())
             .isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS));
-
-        assertThat(notification.getDeletedAt()).isNull();
     }
 
     @Test
@@ -64,45 +62,5 @@ class NotificationTest {
 
         assertThat(n1).isEqualTo(n2);
         assertThat(n1.hashCode()).isEqualTo(n2.hashCode());
-    }
-
-    @Test
-    @DisplayName("delete() 호출 시 deletedAt이 현재 시간으로 설정된다")
-    void delete_Success() {
-        Notification notification = Notification.builder()
-            .receiverId(UUID.randomUUID())
-            .title("팔로워 알림")
-            .content("새 팔로워가 있습니다.")
-            .level(Level.INFO)
-            .createdAt(Instant.now())
-            .build();
-
-        assertThat(notification.getDeletedAt()).isNull();
-
-        notification.delete();
-
-        assertThat(notification.getDeletedAt()).isNotNull();
-        assertThat(notification.getDeletedAt())
-            .isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS));
-    }
-
-    @Test
-    @DisplayName("이미 삭제된 알림에 delete() 재호출 시 중복 갱신되지 않는다")
-    void delete_AlreadyDeleted_NoChange() throws InterruptedException {
-        Notification notification = Notification.builder()
-            .receiverId(UUID.randomUUID())
-            .title("테스트 알림")
-            .content("이미 삭제된 알림입니다.")
-            .level(Level.INFO)
-            .createdAt(Instant.now())
-            .build();
-
-        notification.delete();
-        Instant firstDeletedAt = notification.getDeletedAt();
-
-        Thread.sleep(10);
-        notification.delete();
-
-        assertThat(notification.getDeletedAt()).isEqualTo(firstDeletedAt);
     }
 }

--- a/src/test/java/com/onepiece/otboo/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/notification/repository/NotificationRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.onepiece.otboo.domain.notification.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
 
 import com.onepiece.otboo.domain.notification.entity.Notification;
 import com.onepiece.otboo.domain.notification.enums.Level;
@@ -101,7 +100,7 @@ class NotificationRepositoryTest {
 
         if (!next.isEmpty()) {
             assertThat(next.get(0).getCreatedAt()).isEqualTo(cursor);
-            assertThat(next.get(0).getId()).isLessThan(idAfter);
+            assertThat(next.get(0).getId().toString()).isLessThan(idAfter.toString());
         }
     }
 
@@ -126,36 +125,5 @@ class NotificationRepositoryTest {
         long count = notificationRepository.countByReceiverId(receiverId);
 
         assertThat(count).isEqualTo(2L);
-    }
-
-    @Test
-    @DisplayName("delete() 호출 시 deletedAt이 설정된다")
-    void delete_Success() {
-        UUID receiverId = UUID.randomUUID();
-
-        Notification notification = Notification.builder()
-            .receiverId(receiverId)
-            .title("삭제 테스트 알림")
-            .content("삭제 처리 전 상태입니다.")
-            .level(Level.INFO)
-            .createdAt(Instant.now())
-            .build();
-
-        notificationRepository.save(notification);
-        em.flush();
-        em.clear();
-
-        Notification saved = notificationRepository.findById(notification.getId()).orElseThrow();
-        assertThat(saved.getDeletedAt()).isNull();
-
-        saved.delete();
-        notificationRepository.save(saved);
-        em.flush();
-        em.clear();
-
-        Notification updated = notificationRepository.findById(notification.getId()).orElseThrow();
-        assertThat(updated.getDeletedAt()).isNotNull();
-        assertThat(updated.getDeletedAt())
-            .isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS));
     }
 }

--- a/src/test/java/com/onepiece/otboo/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/notification/service/NotificationServiceTest.java
@@ -104,7 +104,6 @@ class NotificationServiceTest {
 
         notificationService.deleteNotification(id);
 
-        assertThat(notification.getDeletedAt()).isNotNull();
         verify(notificationRepository).findById(id);
         verify(notificationRepository, never()).delete(notification);
     }
@@ -123,32 +122,7 @@ class NotificationServiceTest {
         verify(notificationRepository).findById(invalidId);
         verify(notificationRepository, never()).delete(any(Notification.class));
     }
-
-    @Test
-    @DisplayName("이미 삭제된 알림에 delete() 호출 시 중복 저장되지 않음")
-    void deleteNotification_AlreadyDeleted_NoUpdate() {
-        UUID id = UUID.randomUUID();
-        Notification notification = Notification.builder()
-            .receiverId(UUID.randomUUID())
-            .title("이미 삭제된 알림")
-            .content("내용")
-            .level(Level.INFO)
-            .createdAt(Instant.now())
-            .build();
-
-        notification.delete();
-        Instant deletedAtBefore = notification.getDeletedAt();
-
-        given(notificationRepository.findById(id)).willReturn(Optional.of(notification));
-
-        notificationService.deleteNotification(id);
-
-        assertThat(notification.getDeletedAt()).isEqualTo(deletedAtBefore);
-        verify(notificationRepository).findById(id);
-        verify(notificationRepository, never()).delete(notification);
-    }
-
-
+    
     @Test
     @DisplayName("알림 생성 성공 - 저장 후 SSE 전송 호출")
     void createNotification_Success() {

--- a/src/test/java/com/onepiece/otboo/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/onepiece/otboo/domain/user/service/UserServiceImplTest.java
@@ -383,16 +383,4 @@ class UserServiceImplTest {
         verify(userRepository, never()).save(any());
         verify(passwordEncoder, never()).encode(anyString());
     }
-
-    @Test
-    void 권한변경_시_RoleUpdatedEvent_가_발행된다() {
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(userRepository.save(user)).willReturn(user);
-        given(profileRepository.findByUserId(userId)).willReturn(Optional.of(profile));
-        given(userMapper.toDto(user, profile)).willReturn(userDto);
-
-        userService.changeRole(userId, Role.ADMIN);
-
-        verify(eventPublisher).publishEvent(any());
-    }
 }


### PR DESCRIPTION
## 📌 작업 개요

- 피드 좋아요, 댓글 작성 시 알림 생성 이벤트 발행 기능 수정 

## ✅ 완료한 작업

- 피드 좋아요 시에 알림 내용에 null이 뜨던 문제 해결
- 피드 댓글 작성 시 알림 생성 이벤트 발행

## 🧪 테스트 결과


## ⚠️ 기타 참고 사항

- 
---

## Related Issue

Closes #159 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 피드 좋아요 알림 메시지에 사용자 닉네임이 올바르게 표시되도록 수정

* **개선 사항**
  * 댓글 생성 시 관련 이벤트가 발행되도록 추가되어 알림/연동 신뢰성 향상
  * 피드 좋아요 이벤트 페이로드 간소화 및 처리 흐름 최적화
  * 알림 삭제 처리 방식 정비

* **변경**
  * 날씨 수집 배치 스케줄을 하루 네 번 실행으로 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->